### PR TITLE
load views from trifid folder and not cwd

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -2,12 +2,12 @@
 <html>
 <head>
 
-${include('cwd:views/header.html')}
+${include('trifid:views/header.html')}
 
 </head>
 <body>
 
-${include('cwd:views/navigation.html')}
+${include('trifid:views/navigation.html')}
 
 <div class="container">
   <div class="row">
@@ -20,7 +20,7 @@ ${include('cwd:views/navigation.html')}
     </div>
   </div>
 
-${include('cwd:views/footer.html')}
+${include('trifid:views/footer.html')}
 
 </div>
 

--- a/views/home.html
+++ b/views/home.html
@@ -2,12 +2,12 @@
 <html>
 <head>
 
-${include('cwd:views/header.html')}
+${include('trifid:views/header.html')}
 
 </head>
 <body>
 
-${include('cwd:views/navigation.html')}
+${include('trifid:views/navigation.html')}
 
 <div class="container">
   <div class="row">
@@ -17,7 +17,7 @@ ${include('cwd:views/navigation.html')}
     </div>
   </div>
 
-${include('cwd:views/footer.html')}
+${include('trifid:views/footer.html')}
 
 </div>
 

--- a/views/index.html
+++ b/views/index.html
@@ -3,12 +3,12 @@ ${set('moduleFoot','<li><a href="?format=jsonld">json-ld</a> | <a href="?format=
 <html>
 <head>
 
-${include('cwd:views/header.html')}
+${include('trifid:views/header.html')}
 
 </head>
 <body>
 
-${include('cwd:views/navigation.html')}
+${include('trifid:views/navigation.html')}
 
 <div class="container">
   <div class="row">
@@ -19,7 +19,7 @@ ${include('cwd:views/navigation.html')}
     </div>
   </div>
 
-${include('cwd:views/footer.html')}
+${include('trifid:views/footer.html')}
 
 </div>
 


### PR DESCRIPTION
`header.html`, `navigation.html` and `footer.html` are currently loaded from the `cwd`, which enforces making copies of the views to a project which uses Trifid as a dependency, even if no changes are made. This PR changes `index.html`, `error.html` and `home.html` to use `header.html`, `navigation.html` and `footer.html` from the `trifid` folder. This was a bug, as Trifid should run just with a config or even without config, if a SPARQL endpoint is used. But the bug could have been used to change only the `header.html`, `navigation.html` and `footer.html` views without copying `index.html`, `error.html` and `home.html`. After merging this PR customizing the views requires to copy all views to the project folder, which uses Trifid as dependency.