### PR TITLE
better debug logging

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2019 Zazuko GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Note that this module does _not_ work for most content-types, see the documentat
 
 ## Production Best Practices
 
-Note that it is not recommended to run Node applications on [well-known ports](http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports) (< 1024). You should use a reverse proxy like [Varnish](https://www.varnish-cache.org/) instead.
+Note that it is not recommended to run Node applications on [well-known ports](http://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports) (< 1024). You should use a reverse proxy instead.
 
 ### Installing/Using with Docker
 
@@ -260,6 +260,12 @@ If you do not want to build your own Docker image, you can pull the official ima
 
 If you run Trifid behind a reverse proxy, the proxy must set the `X-Forwarded-Host` header field.
 
+## Debugging
+
+This package uses [`debug`](https://www.npmjs.com/package/debug), you can get debug logging via: `DEBUG=trifid:`.
+Trifid plugins should also implement `debug` under the `trifid:` prefix, enabling logging from all packages
+implementing it can be done this way: `DEBUG=trifid:*`.
+
 ## Support
 
 Issues & feature requests should be reported on Github.
@@ -268,6 +274,6 @@ Pull requests are very welcome.
 
 ## License
 
-Copyright 2015-2017 Zazuko GmbH
+Copyright 2015-2019 Zazuko GmbH
 
 Trifid is licensed under the Apache License, Version 2.0. Please see LICENSE and NOTICE for details.

--- a/package.json
+++ b/package.json
@@ -38,6 +38,6 @@
     "trifid-yasgui": "^2.0.5"
   },
   "devDependencies": {
-    "standard": "^10.0.3"
+    "standard": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "trifid",
   "description": "Trifid - Lightweight Linked Data Server and Proxy",
   "version": "2.1.1",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/zazuko/trifid",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "camouflage-rewrite": "^1.2.0",
     "compression": "^1.7.2",
+    "debug": "^4.1.1",
     "format-to-accept": "^1.0.0",
     "morgan": "^1.9.0",
     "patch-headers": "^1.0.1",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+const debug = require('debug')('trifid:')
 const path = require('path')
 const program = require('commander')
 const ConfigHandler = require('trifid-core/lib/ConfigHandler')
@@ -47,11 +48,11 @@ trifid.configHandler.resolver.use('trifid', ConfigHandler.pathResolver(__dirname
 
 trifid.init(config).then(() => {
   if (program.verbose) {
-    console.log('expanded config:')
-    console.log(JSON.stringify(trifid.config, null, ' '))
+    debug('expanded config:')
+    debug(JSON.stringify(trifid.config, null, ' '))
   }
 
   return trifid.app()
 }).catch((err) => {
-  console.error(err.stack || err.message)
+  debug(err)
 })


### PR DESCRIPTION
Using `trifid:` as root namespace to get logs with `trifid:*`