### PR TITLE
Setup Kustomize and Skaffold, and rewrite the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,44 @@
-FROM node:carbon
+FROM node:lts-alpine
 
-# install pm2 process manager
-RUN npm install pm2 -g
+WORKDIR /app
 
-# install trifid globaly accessible
-RUN mkdir -p /opt/trifid
-WORKDIR /opt/trifid
-COPY . /opt/trifid
-RUN npm install -g --only=production
+# Copy the package.json and install the dependencies
+COPY package.json ./
+COPY .npmrc ./
+RUN npm install --only=production
+COPY . .
+RUN ln -s /app/server.js /usr/local/bin/trifid
 
-# create application directory
-RUN mkdir -p /usr/src/app
-RUN ln -s /opt/trifid/node_modules /usr/src/app
-WORKDIR /usr/src/app
-# copy necessary files, overwrite for your instance
-COPY config.json ./
-COPY views ./views
-COPY public ./public
+USER nobody:nobody
 
-CMD ["pm2-docker", "trifid"]
+# Ideally set those for published images. To do so, run something like
+#
+#   docker build . \
+#     --tag YOUR_TAG \
+#     --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
+#     --build-arg COMMIT=$(git rev-parse HEAD) \
+#     --build-arg VERSION=$(git describe)
+#
+ARG BUILD_DATE
+ARG COMMIT
+ARG VERSION
+
+LABEL org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.name="Trifid" \
+      org.label-schema.description="Lightweight Linked Data Server and Proxy" \
+      org.label-schema.url="https://github.com/zazuko/trifid" \
+      org.label-schema.vcs-url="https://github.com/zazuko/trifid" \
+      org.label-schema.vcs-ref=$COMMIT \
+      org.label-schema.vendor="Zazuko" \
+      org.label-schema.version=$VERSION \
+      org.label-schema.schema-version="1.0"
+
+ENTRYPOINT []
+
+# Using npm scripts for running the app allows two things:
+#  - Handle signals correctly (Node does not like to be PID1)
+#  - Let Skaffold detect it's a node app so it can attach the Node debugger
+CMD ["npm", "run", "start"]
 
 EXPOSE 8080
+HEALTHCHECK CMD wget -q -O- http://localhost:8080/health

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trifid
+spec:
+  replicas: 1
+  template:
+    spec:
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+      containers:
+      - name: trifid
+        image: "docker.io/zazuko/trifid:latest"
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: http

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: trifid
+
+resources:
+- deployment.yaml
+- service.yaml

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trifid
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "url": "https://github.com/zazuko/trifid/issues"
   },
   "scripts": {
+    "start": "node server.js",
     "test": "standard"
   },
   "bin": {

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,20 @@
+apiVersion: skaffold/v1beta11
+kind: Config
+build:
+  tagPolicy:
+    sha256: {}
+  artifacts:
+  - image: docker.io/zazuko/trifid
+    docker:
+      buildArgs:
+        # Set build args from env
+        # See Dockerfile for details
+        BUILD_DATE: '{{ .BUILD_DATE }}'
+        COMMIT: '{{ .COMMIT }}'
+        VERSION: '{{ .VERSION }}'
+  local:
+    # See https://github.com/GoogleContainerTools/skaffold/issues/2234
+    useDockerCLI: true
+deploy:
+  kustomize:
+    path: "k8s/"


### PR DESCRIPTION
In this PR, I rewrote the dockerfile (tweaked a bit the one from #50), added Kustomize manifests and setup Skaffold.

Kustomize is a tool to manage kubernetes manifests, with patches for different environments (dev/staging/prod). It is also able to mix multiple bases, including bases from other git repositories.
I plan to use the base defined here with a few overrides for other projects where we use Trifid.

Skaffold is a tool to build images and deploy them in kubernetes clusters. One great thing about Skaffold is that it automatically generates images tags according to rules (image hash, git commit, git tag, build date, …).

To try this, install Skaffold and Kustomize. Setup a local kubernetes cluster (there's an option for that in Docker for Desktop ; on Linux the easiest way to do is to use minikube).
Then run:

 - `skaffold dev --port-forward` to run in dev mode. Skaffold should forward the 8080 port locally. It will watch for file changes and rebuild the image when needed.
 - `skaffold debug --port-forward` should do the same, but with the node debugger enabled. You should be able to attach the chrome inspector in `chrome://inspect`.

Note that both commands will try to push to the registry (`docker.io/zazuko/trifid`) if Skaffold does not detect that the current kubernetes cluster is a local cluster.
Also the port-forward and debugger thing also work on remote clusters, which is always great 🎉 