### PR TITLE
Use zazuko URL shortener in yasgui plugin config

### DIFF
--- a/config-sparql.json
+++ b/config-sparql.json
@@ -26,7 +26,8 @@
   },
   "yasgui": {
     "default": {
-      "path": "/sparql"
+      "path": "/sparql",
+      "urlShortener": "https://s.zazuko.com/api/v1/shorten"
     }
   },
   "breakDown": {


### PR DESCRIPTION
Together with https://github.com/zazuko/trifid-plugin-yasgui/pull/2 , fixes https://github.com/zazuko/trifid/issues/76

---

I'll merge and publish after trifid-plugin-yasgui is published and trifid-plugin-yasgui version is updated in `config-sparql.json`