### PR TITLE
Load config file from env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@ FROM node:lts-alpine
 
 WORKDIR /app
 
+# Use tini for PID1
+# https://github.com/krallin/tini
+RUN apk add --no-cache tini
+
 # Copy the package.json and install the dependencies
 COPY package.json ./
 COPY .npmrc ./
@@ -18,12 +22,9 @@ LABEL org.label-schema.name="Trifid" \
       org.label-schema.vendor="Zazuko" \
       org.label-schema.schema-version="1.0"
 
-ENTRYPOINT []
+ENTRYPOINT ["tini", "--", "/app/server.js"]
 
-# Using npm scripts for running the app allows two things:
-#  - Handle signals correctly (Node does not like to be PID1)
-#  - Let Skaffold detect it's a node app so it can attach the Node debugger
-CMD ["npm", "run", "start"]
+ENV TRIFID_CONFIG config.json
 
 EXPOSE 8080
 HEALTHCHECK CMD wget -q -O- http://localhost:8080/health

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -16,7 +16,7 @@ If you just want to execute Trifid without much tweaking, the easiest way is to 
 
 The default configuration won't do much so you need to specify a different configuration file, as described below. Once you have an adjusted config file run the image:
 
-     docker run -ti -e TRIFID_CONFIG=config-custom.json -v $(pwd)/config-custom.json:/usr/src/app/config-custom.json -p 8080:8080 zazuko/trifid
+     docker run -ti -e TRIFID_CONFIG=config-custom.json -v $(pwd)/config-custom.json:/app/config-custom.json -p 8080:8080 zazuko/trifid
 
 With `-e TRIFID_CONFIG=config-custom.json` we override the configuration file, `-v` mounts the local config file into the container. The `$(pwd)` is necessary as `-v` does not support relative paths.
 
@@ -27,7 +27,7 @@ In case you want to do the same with `docker-compose, a YAML file should contain
     container_name: myfancyname
     image: zazuko/trifid
     volumes:
-      - ./config-custom.json:/usr/src/app/config-custom.json
+      - ./config-custom.json:/app/config-custom.json
     environment:
       - TRIFID_CONFIG=config-custom.json
 ```

--- a/server.js
+++ b/server.js
@@ -8,15 +8,17 @@ const Trifid = require('trifid-core')
 
 program
   .option('-v, --verbose', 'verbose output', () => true)
-  .option('-c, --config <path>', 'configuration file', 'config.json')
+  .option('-c, --config <path>', 'configuration file', process.env.TRIFID_CONFIG)
   .option('-p, --port <port>', 'listener port', parseInt)
   .option('--sparql-endpoint-url <url>', 'URL of the SPARQL HTTP query interface')
   .option('--dataset-base-url <url>', 'Base URL of the dataset')
   .parse(process.argv)
 
 // automatically switch to config-sparql if a SPARQL endpoint URL is given and no config file was defined
-if (program.sparqlEndpointUrl && program.config === 'config.json') {
+if (program.sparqlEndpointUrl && !program.config) {
   program.config = 'config-sparql.json'
+} else if (!program.config) {
+  program.config = 'config.json'
 }
 
 // create a minimal configuration with a baseConfig pointing to the given config file


### PR DESCRIPTION
In the past it was possible to set the config file path using the `TRIFID_CONFIG` environment variable in the docker setup. That was done with some env expansion in the dockerfile. This re-adds this feature, but extends it to the node app itself.

Also uses `tini` as PID1 instead of npm start, see https://www.elastic.io/nodejs-as-pid-1-under-docker-images/