### PR TITLE
Improve Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,42 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v*.*.*"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        uses: zazuko/action-docker-meta@main
+        id: docker_meta
+        with:
+          images: ghcr.io/zazuko/trifid
+
+      - name: Build and push Docker images
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -40,3 +43,10 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+          platforms: |
+            linux/amd64
+            linux/arm/v6
+            linux/arm/v7
+            linux/arm64/v8
+            linux/ppc64le
+            linux/s390x

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -45,8 +45,4 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           platforms: |
             linux/amd64
-            linux/arm/v6
-            linux/arm/v7
             linux/arm64/v8
-            linux/ppc64le
-            linux/s390x

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/node:16-alpine
 
 EXPOSE 8080
 
-ENV TRIFID_CONFIG="config.json"
+ENV TRIFID_CONFIG="config-docker.json"
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,25 @@
 FROM docker.io/library/node:16-alpine
 
+EXPOSE 8080
+
+ENV TRIFID_CONFIG="config.json"
+
 WORKDIR /app
 
-# Use tini for PID1
+# use tini for PID1
 # https://github.com/krallin/tini
 RUN apk add --no-cache tini
 
-# Copy the package.json and install the dependencies
+# copy package.json and install dependencies
 COPY package.json ./
 COPY .npmrc ./
 RUN npm install --only=production
 COPY . .
 RUN ln -s /app/server.js /usr/local/bin/trifid
 
-USER nobody:nobody
-
-LABEL org.label-schema.name="Trifid" \
-      org.label-schema.description="Lightweight Linked Data Server and Proxy" \
-      org.label-schema.url="https://github.com/zazuko/trifid" \
-      org.label-schema.vcs-url="https://github.com/zazuko/trifid" \
-      org.label-schema.vendor="Zazuko" \
-      org.label-schema.schema-version="1.0"
+# run as nobody
+USER 65534:65534
 
 ENTRYPOINT ["tini", "--", "/app/server.js"]
 
-ENV TRIFID_CONFIG config.json
-
-EXPOSE 8080
 HEALTHCHECK CMD wget -q -O- http://localhost:8080/health

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM docker.io/library/node:16-alpine
 
 WORKDIR /app
 

--- a/config-docker.json
+++ b/config-docker.json
@@ -1,0 +1,16 @@
+{
+  "baseConfig": "trifid:config-sparql.json",
+  "sparqlEndpointUrl": "env:SPARQL_ENDPOINT_URL",
+  "datasetBaseUrl": "env:DATASET_BASE_URL",
+  "sparqlEndpointAuthentication": {
+    "user": "env:SPARQL_USER",
+    "password": "env:SPARQL_PASSWORD"
+  },
+  "sparqlProxy": {
+    "default": {
+      "options": {
+        "queryOperation": "postQueryUrlencoded"
+      }
+    }
+  }
+}

--- a/server.js
+++ b/server.js
@@ -28,8 +28,6 @@ const config = {
   baseConfig: path.join(process.cwd(), opts.config)
 }
 
-console.log('config', config)
-
 // add optional arguments to the configuration
 
 if (opts.port) {


### PR DESCRIPTION
Closes #106 

The following Docker image is created using GitHub Actions: `ghcr.io/zazuko/trifid`

It supports the following architectures:
- amd64
- arm64

Here are some environment variables that can be used to configure the Docker image:
- `SPARQL_ENDPOINT_URL`: configure the SPARQL endpoint
- `DATASET_BASE_URL`: configure the dataset base URL
- `SPARQL_USER`: the user to authenticate against the SPARQL endpoint
- `SPARQL_PASSWORD`: the password to authenticate against the SPARQL endpoint

If you need to override some configuration, you can mount a file in the `/app` directory in the Docker image, and set the `TRIFID_CONFIG` environment variable to point to the file, relatively to the `/app` directory.