### PR TITLE
Remove tests using Node 16

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 16
           - 18
           - 20
 


### PR DESCRIPTION
Since Node 16 is dead, we don't have to support it anymore.
This removes the tests using Node 16, so that we are not running useless runners.