### PR TITLE
Improve tests and fix some bugs

### DIFF
--- a/.changeset/clever-snakes-judge.md
+++ b/.changeset/clever-snakes-judge.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+Use map instead of forEach in label loader.

--- a/.changeset/olive-dogs-reply.md
+++ b/.changeset/olive-dogs-reply.md
@@ -1,0 +1,5 @@
+---
+"trifid-core": patch
+---
+
+Do not display a body in case of errors. This is not possible without breaking components that are using hijackresponse for now.

--- a/.changeset/olive-dogs-reply.md
+++ b/.changeset/olive-dogs-reply.md
@@ -2,4 +2,5 @@
 "trifid-core": patch
 ---
 
-Do not display a body in case of errors. This is not possible without breaking components that are using hijackresponse for now.
+Do not display a body in case of errors.
+This is not possible without breaking components that are using hijackresponse for now.

--- a/packages/core/middlewares/errors.js
+++ b/packages/core/middlewares/errors.js
@@ -7,13 +7,13 @@ const factory = (trifid) => {
   return (err, _req, res, _next) => {
     logger.error(err.stack)
 
-    let status = res.statusCode || 500
+    res.statusCode = res.statusCode || 500
     // handle the case where there is an error, but no specific status code has been set
-    if (status < 400) {
-      status = 500
+    if (res.statusCode < 400) {
+      res.statusCode = 500
     }
 
-    res.sendStatus(status)
+    res.end()
   }
 }
 

--- a/packages/core/test/middlewares/errors.test.js
+++ b/packages/core/test/middlewares/errors.test.js
@@ -43,7 +43,7 @@ describe('errors middleware', () => {
     return request(app).get('/').expect(502)
   })
 
-  test('should return a body containing the description of the status code', async () => {
+  test('should return an empty body in case of internal error', async () => {
     const app = express()
 
     const throwingMiddleware = (_req, _res, _next) => {
@@ -59,6 +59,6 @@ describe('errors middleware', () => {
       }),
     )
 
-    return request(app).get('/').expect('Internal Server Error')
+    return request(app).get('/').expect('')
   })
 })

--- a/packages/entity-renderer/renderer/labels/labelLoader.js
+++ b/packages/entity-renderer/renderer/labels/labelLoader.js
@@ -72,7 +72,7 @@ class LabelLoader {
 
   getTermsWithoutLabel (pointer) {
     const result = rdf.termSet()
-    pointer.dataset.forEach((quad) => {
+    pointer.dataset.map((quad) => {
       if (this.labelFilter(pointer, quad.subject)) {
         result.add(quad.subject)
       }
@@ -82,6 +82,7 @@ class LabelLoader {
       if (this.labelFilter(pointer, quad.object)) {
         result.add(quad.object)
       }
+      return quad
     })
     return result
   }

--- a/packages/entity-renderer/test/entity-renderer.test.js
+++ b/packages/entity-renderer/test/entity-renderer.test.js
@@ -26,6 +26,30 @@ describe('@zazuko/trifid-plugin-ckan', () => {
         const entityUrl = `${getListenerURL(trifidListener)}/person/amy-farrah-fowler`
         const res = await fetch(entityUrl)
         strictEqual(res.status, 200)
+        const resText = await res.text()
+        strictEqual(resText.toLocaleLowerCase().includes('amy'), true)
+      } catch (e) {
+        throw e
+      } finally {
+        trifidListener.close()
+      }
+    })
+
+    it('should be able to load a rendered entity using HTML', async () => {
+      const trifidInstance = await createTrifidInstance(trifidConfigUrl, 'warn')
+      const trifidListener = await trifidInstance.start()
+
+      try {
+        const entityUrl = `${getListenerURL(trifidListener)}/person/amy-farrah-fowler`
+        const res = await fetch(entityUrl, {
+          headers: {
+            accept: 'text/html',
+          },
+        })
+        strictEqual(res.status, 200)
+        const resText = await res.text()
+        strictEqual(resText.toLocaleLowerCase().includes('<html'), true)
+        strictEqual(resText.toLocaleLowerCase().includes('amy'), true)
       } catch (e) {
         throw e
       } finally {


### PR DESCRIPTION
This PR is doing the following:
- send an empty body message in case of error, this fix some unexpected issues with the use of `hijackresponse` (that we will try to remove in the future)
- fix an issue in entity renderer plugin for the label loader, where the `forEach` method is not available due to the replacement of `rdf-ext` with `@zazuko/env`
- improve tests for the entity renderer: it's now able to check if it is rendered as HTML also