### PR TITLE
CKAN: Convert legacy frequency to EU frequency

### DIFF
--- a/.changeset/warm-seas-brush.md
+++ b/.changeset/warm-seas-brush.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": minor
+---
+
+Convert legacy frequency to EU frequency

--- a/packages/ckan/README.md
+++ b/packages/ckan/README.md
@@ -58,7 +58,7 @@ The following properties are populated by the endpoint:
 
   Supports both DC (http://purl.org/cld/freq/) and EU
   (http://publications.europa.eu/ontology/euvoc#Frequency) frequencies.
-  Transforms EU frequencies to DC ones using their `skos:exactMatch`.
+  DC frequencies are transformed into EU ones.
 
 - `dcat:distribution`
 

--- a/packages/ckan/src/index.js
+++ b/packages/ckan/src/index.js
@@ -2,6 +2,7 @@
 import rdf from '@zazuko/env'
 import { createAPI } from './ckan.js'
 
+/** @type {import('trifid-core/types/index.d.ts').TrifidMiddleware} */
 const factory = (trifid) => {
   const { config, logger } = trifid
 

--- a/packages/ckan/src/namespace.js
+++ b/packages/ckan/src/namespace.js
@@ -1,3 +1,4 @@
+// @ts-check
 import _rdf from '@zazuko/env'
 
 const { dcat, dcterms, rdf, schema, skos } = _rdf.ns

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -86,15 +86,15 @@ const toXML = (dataset) => {
 
           // Datasets contain a mix of legacy (DC) frequencies and new (EU) frequencies.
           // The query makes sure we get both legacy and new ones, we only
-          // provide the legacy ones to CKAN.
-          const legacyFreqPrefix = 'http://purl.org/cld/freq/'
+          // provide the new ones to CKAN, by converting legacy ones if needed.
+          const legacyFreqPrefix = 'http://publications.europa.eu/resource/authority/frequency/'
           const accrualPeriodicity = dataset.out(ns.dcterms.accrualPeriodicity)
             .map((t) => {
               if (!t.term || !t.term.value) {
                 return t
               }
-              // If the frequency is not a EU frequency, it is returned unchanged.
-              t.term.value = convertEUFrequencyToLegacy(t.term.value)
+              // If the frequency is not a legacy frequency, it is returned unchanged.
+              t.term.value = convertLegacyFrequency(t.term.value)
               return t
             })
             .filter(({ term }) => term.value.startsWith(legacyFreqPrefix))
@@ -213,51 +213,51 @@ const distributionFormatFromEncoding = (encodingPointer) => {
 }
 
 /**
- * Convert EU frequency to legacy frequency if possible.
- * If the frequency is not a EU frequency, it is returned unchanged.
- * If there is no mapping for the EU frequency, it is returned unchanged.
+ * Convert legacy frequency to EU frequency if possible.
+ * If the frequency is not a legacy frequency, it is returned unchanged.
  *
  * @param {string} frequency Frequency to convert.
  * @returns {string} Converted frequency.
  */
-const convertEUFrequencyToLegacy = (frequency) => {
+export const convertLegacyFrequency = (frequency) => {
   const legacyFreqPrefix = 'http://purl.org/cld/freq'
   const euFreqPrefix = 'http://publications.europa.eu/resource/authority/frequency'
+
   switch (frequency) {
-    case `${euFreqPrefix}/ANNUAL`:
-      return `${legacyFreqPrefix}/annual`
-    case `${euFreqPrefix}/ANNUAL_2`:
-      return `${legacyFreqPrefix}/semiannual`
-    case `${euFreqPrefix}/ANNUAL_3`:
-      return `${legacyFreqPrefix}/threeTimesAYear`
-    case `${euFreqPrefix}/BIENNIAL`:
-      return `${legacyFreqPrefix}/biennial`
-    case `${euFreqPrefix}/BIMONTHLY`:
-      return `${legacyFreqPrefix}/bimonthly`
-    case `${euFreqPrefix}/BIWEEKLY`:
-      return `${legacyFreqPrefix}/biweekly`
-    case `${euFreqPrefix}/CONT`:
-      return `${legacyFreqPrefix}/continuous`
-    case `${euFreqPrefix}/DAILY`:
-      return `${legacyFreqPrefix}/daily`
-    case `${euFreqPrefix}/IRREG`:
-      return `${legacyFreqPrefix}/irregular`
-    case `${euFreqPrefix}/MONTHLY`:
-      return `${legacyFreqPrefix}/monthly`
-    case `${euFreqPrefix}/MONTHLY_2`:
-      return `${legacyFreqPrefix}/semimonthly`
-    case `${euFreqPrefix}/MONTHLY_3`:
-      return `${legacyFreqPrefix}/threeTimesAMonth`
-    case `${euFreqPrefix}/QUARTERLY`:
-      return `${legacyFreqPrefix}/quarterly`
-    case `${euFreqPrefix}/TRIENNIAL`:
-      return `${legacyFreqPrefix}/triennial`
-    case `${euFreqPrefix}/WEEKLY`:
-      return `${legacyFreqPrefix}/weekly`
-    case `${euFreqPrefix}/WEEKLY_2`:
-      return `${legacyFreqPrefix}/semiweekly`
-    case `${euFreqPrefix}/WEEKLY_3`:
-      return `${legacyFreqPrefix}/threeTimesAWeek`
+    case `${legacyFreqPrefix}/annual`:
+      return `${euFreqPrefix}/ANNUAL`
+    case `${legacyFreqPrefix}/semiannual`:
+      return `${euFreqPrefix}/ANNUAL_2`
+    case `${legacyFreqPrefix}/threeTimesAYear`:
+      return `${euFreqPrefix}/ANNUAL_3`
+    case `${legacyFreqPrefix}/biennial`:
+      return `${euFreqPrefix}/BIENNIAL`
+    case `${legacyFreqPrefix}/bimonthly`:
+      return `${euFreqPrefix}/BIMONTHLY`
+    case `${legacyFreqPrefix}/biweekly`:
+      return `${euFreqPrefix}/BIWEEKLY`
+    case `${legacyFreqPrefix}/continuous`:
+      return `${euFreqPrefix}/CONT`
+    case `${legacyFreqPrefix}/daily`:
+      return `${euFreqPrefix}/DAILY`
+    case `${legacyFreqPrefix}/irregular`:
+      return `${euFreqPrefix}/IRREG`
+    case `${legacyFreqPrefix}/monthly`:
+      return `${euFreqPrefix}/MONTHLY`
+    case `${legacyFreqPrefix}/semimonthly`:
+      return `${euFreqPrefix}/MONTHLY_2`
+    case `${legacyFreqPrefix}/threeTimesAMonth`:
+      return `${euFreqPrefix}/MONTHLY_3`
+    case `${legacyFreqPrefix}/quarterly`:
+      return `${euFreqPrefix}/QUARTERLY`
+    case `${legacyFreqPrefix}/triennial`:
+      return `${euFreqPrefix}/TRIENNIAL`
+    case `${legacyFreqPrefix}/weekly`:
+      return `${euFreqPrefix}/WEEKLY`
+    case `${legacyFreqPrefix}/semiweekly`:
+      return `${euFreqPrefix}/WEEKLY_2`
+    case `${legacyFreqPrefix}/threeTimesAWeek`:
+      return `${euFreqPrefix}/WEEKLY_3`
   }
   return frequency
 }

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -8,6 +8,7 @@ import { describe, it } from 'mocha'
 
 import trifidCore from 'trifid-core'
 import ckanTrifidPlugin from '../src/index.js'
+import { convertLegacyFrequency } from '../src/xml.js'
 import { storeMiddleware } from './support/store.js'
 import { getListenerURL } from './support/utils.js'
 
@@ -97,6 +98,51 @@ describe('@zazuko/trifid-plugin-ckan', () => {
       } finally {
         trifidListener.close()
       }
+    })
+
+    it('should convert legacy frequency to EU frequency if possible', async () => {
+      const legacyFreqPrefix = 'http://purl.org/cld/freq'
+      const euFreqPrefix = 'http://publications.europa.eu/resource/authority/frequency'
+
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/annual`), `${euFreqPrefix}/ANNUAL`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/semiannual`), `${euFreqPrefix}/ANNUAL_2`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/threeTimesAYear`), `${euFreqPrefix}/ANNUAL_3`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/biennial`), `${euFreqPrefix}/BIENNIAL`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/bimonthly`), `${euFreqPrefix}/BIMONTHLY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/biweekly`), `${euFreqPrefix}/BIWEEKLY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/continuous`), `${euFreqPrefix}/CONT`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/daily`), `${euFreqPrefix}/DAILY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/irregular`), `${euFreqPrefix}/IRREG`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/monthly`), `${euFreqPrefix}/MONTHLY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/semimonthly`), `${euFreqPrefix}/MONTHLY_2`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/threeTimesAMonth`), `${euFreqPrefix}/MONTHLY_3`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/quarterly`), `${euFreqPrefix}/QUARTERLY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/triennial`), `${euFreqPrefix}/TRIENNIAL`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/weekly`), `${euFreqPrefix}/WEEKLY`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/semiweekly`), `${euFreqPrefix}/WEEKLY_2`)
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/threeTimesAWeek`), `${euFreqPrefix}/WEEKLY_3`)
+
+      // Should not convert unknown frequencies
+      strictEqual(convertLegacyFrequency(`${legacyFreqPrefix}/unknown`), `${legacyFreqPrefix}/unknown`)
+
+      // Should not convert EU frequencies
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/ANNUAL`), `${euFreqPrefix}/ANNUAL`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/ANNUAL_2`), `${euFreqPrefix}/ANNUAL_2`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/ANNUAL_3`), `${euFreqPrefix}/ANNUAL_3`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/BIENNIAL`), `${euFreqPrefix}/BIENNIAL`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/BIMONTHLY`), `${euFreqPrefix}/BIMONTHLY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/BIWEEKLY`), `${euFreqPrefix}/BIWEEKLY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/CONT`), `${euFreqPrefix}/CONT`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/DAILY`), `${euFreqPrefix}/DAILY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/IRREG`), `${euFreqPrefix}/IRREG`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/MONTHLY`), `${euFreqPrefix}/MONTHLY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/MONTHLY_2`), `${euFreqPrefix}/MONTHLY_2`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/MONTHLY_3`), `${euFreqPrefix}/MONTHLY_3`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/QUARTERLY`), `${euFreqPrefix}/QUARTERLY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/TRIENNIAL`), `${euFreqPrefix}/TRIENNIAL`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/WEEKLY`), `${euFreqPrefix}/WEEKLY`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/WEEKLY_2`), `${euFreqPrefix}/WEEKLY_2`)
+      strictEqual(convertLegacyFrequency(`${euFreqPrefix}/WEEKLY_3`), `${euFreqPrefix}/WEEKLY_3`)
     })
   })
 })

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -15,7 +15,7 @@
         <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-10-31</dcterms:issued>
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-10-31T15:15:15Z</dcterms:modified>
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
-        <dcterms:accrualPeriodicity rdf:resource="http://purl.org/cld/freq/irregular"/>
+        <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
       </dcat:Dataset>
     </dcat:dataset>
     <dcat:dataset>
@@ -32,7 +32,7 @@
         <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-11-21</dcterms:issued>
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-11-21T11:12:13Z</dcterms:modified>
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
-        <dcterms:accrualPeriodicity rdf:resource="http://purl.org/cld/freq/semiannual"/>
+        <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/ANNUAL_2"/>
       </dcat:Dataset>
     </dcat:dataset>
   </dcat:Catalog>


### PR DESCRIPTION
This PR converts legacy frequencies to EU frequencies, as required here: https://handbook.opendata.swiss/fr/content/glossar/bibliothek/dcat-ap-ch.html#dct-accrual-periodicity-dcat.