### PR TITLE
Change default prefix

### DIFF
--- a/.changeset/famous-pumpkins-work.md
+++ b/.changeset/famous-pumpkins-work.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-markdown-content": patch
+---
+
+Use 'markdown-content-' as id prefix, instead of 'content-'.

--- a/packages/markdown-content/src/index.js
+++ b/packages/markdown-content/src/index.js
@@ -30,7 +30,7 @@ const convertToHtml = async (markdownString) => {
     .use(remarkGfm)
     .use(remarkRehype)
     .use(rehypeSlug, {
-      prefix: 'content-',
+      prefix: 'markdown-content-',
     })
     .use(rehypeAutolinkHeadings, {
       behavior: 'wrap',


### PR DESCRIPTION
Use 'markdown-content-' as id prefix, instead of 'content-'.