### PR TITLE
Change default prefix to `content-`

### DIFF
--- a/.changeset/dry-seals-marry.md
+++ b/.changeset/dry-seals-marry.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-markdown-content": patch
+---
+
+Change default value for `idPrefix` from `markdown-content-` to `content-`.

--- a/packages/markdown-content/README.md
+++ b/packages/markdown-content/README.md
@@ -54,7 +54,7 @@ The following options are supported:
 You can define them in the `defaults` section or in specific entries in the `entries` section.
 Those options are all optional.
 
-- `idPrefix`: The prefix to use for the generated IDs for headings (default: `markdown-content-`).
+- `idPrefix`: The prefix to use for the generated IDs for headings (default: `content-`).
 - `classes`: The classes to add to the generated HTML (default: `{}`). Keys should be the CSS selectors, and values should be the classes to add.
 - `autoLink`: If `true`, will automatically add links to headings (default: `true`).
 - `template`: Path to an alternative template (default: `views/content.hbs`).
@@ -78,7 +78,7 @@ middlewares:
     order: 80
     config:
       defaults:
-        idPrefix: markdown-content-
+        idPrefix: content-
         classes:
           h1: custom-h1
           h2: custom-h2

--- a/packages/markdown-content/src/index.js
+++ b/packages/markdown-content/src/index.js
@@ -181,7 +181,7 @@ const factory = async (trifid) => {
   const defaults = config?.defaults || {}
 
   // Default configuration
-  const idPrefix = defaultValue('idPrefix', defaults, 'markdown-content-')
+  const idPrefix = defaultValue('idPrefix', defaults, 'content-')
   const classes = defaultValue('classes', defaults, {})
   const autoLink = defaultValue('autoLink', defaults, true)
   const template = defaultValue('template', defaults, `${currentDir}/../views/content.hbs`)

--- a/packages/markdown-content/test/index.test.js
+++ b/packages/markdown-content/test/index.test.js
@@ -411,7 +411,7 @@ describe('@zazuko/trifid-markdown-content', () => {
 
         const res = await fetch(pluginUrl)
         const body = await res.text()
-        const match = body.match(/ href="#markdown-content-title"/) || false
+        const match = body.match(/ href="#content-title"/) || false
 
         strictEqual(res.status, 200)
         strictEqual(match && match.length > 0, true)
@@ -472,7 +472,7 @@ describe('@zazuko/trifid-markdown-content', () => {
 
         const res = await fetch(pluginUrl)
         const body = await res.text()
-        const match = body.match(/ href="#markdown-content-title"/) || false
+        const match = body.match(/ href="#content-title"/) || false
 
         strictEqual(res.status, 200)
         strictEqual(match && match.length > 0, false)
@@ -604,7 +604,7 @@ describe('@zazuko/trifid-markdown-content', () => {
 
         const res = await fetch(pluginUrl)
         const body = await res.text()
-        const match = body.match(/ href="#markdown-content-title"/) || false
+        const match = body.match(/ href="#content-title"/) || false
 
         strictEqual(res.status, 200)
         strictEqual(match && match.length > 0, true)
@@ -669,7 +669,7 @@ describe('@zazuko/trifid-markdown-content', () => {
 
         const res = await fetch(pluginUrl)
         const body = await res.text()
-        const match = body.match(/ href="#markdown-content-title"/) || false
+        const match = body.match(/ href="#content-title"/) || false
 
         strictEqual(res.status, 200)
         strictEqual(match && match.length > 0, false)


### PR DESCRIPTION
Since the rendered version is HTML, it makes no sense to have `markdown` in the prefix of the generated IDs for content headings.

Users can configure the prefix to use by using the `idPrefix` option.
See the README.md file for more information on how to use this configuration option.