### PR TITLE
entity-renderer: remove content-disposition from response

### DIFF
--- a/.changeset/stale-humans-grow.md
+++ b/.changeset/stale-humans-grow.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+remove content-disposition from response

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -101,6 +101,7 @@ const factory = async (trifid) => {
         config,
       })
       res.setHeader('Content-Type', 'text/html')
+      res.removeHeader('Content-Disposition')
     } catch (e) {
       logger.error(e)
       return readable.pipe(writable)


### PR DESCRIPTION
We experienced the same issue as https://github.com/zazuko/trifid/issues/169 using eclipse/rdf4j-workbench. An nq file was downloaded instead of displaying the subject page.

The cause of this issue is that the response from the sparql endpoint is re-used. Rdf4j workbench adds the following header to this response: 

`Content-Disposition: attachment; filename=query-result.nq`

This header causes the browser to download the response instead of displaying the html result from the entity-renderer. I assume that Blazegraph (as in issue https://github.com/zazuko/trifid/issues/169 and https://github.com/zazuko/trifid/issues/170) does the same.
