### PR TITLE
ci: add step to check types

### DIFF
--- a/.changeset/sharp-brooms-dream.md
+++ b/.changeset/sharp-brooms-dream.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": patch
+---
+
+Add type declarations to package

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,3 +31,14 @@ jobs:
 
       - name: Run tests
         run: npm run test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx wsrun --report -mc prepack

--- a/package-lock.json
+++ b/package-lock.json
@@ -20038,8 +20038,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "optional": true,
-      "peer": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21026,7 +21025,8 @@
         "c8": "^8.0.1",
         "mocha": "^10.2.0",
         "oxigraph": "^0.3.22",
-        "trifid-core": "^2.7.1"
+        "trifid-core": "^2.7.1",
+        "typescript": "5.3.3"
       }
     },
     "packages/core": {

--- a/packages/ckan/.gitignore
+++ b/packages/ckan/.gitignore
@@ -1,2 +1,4 @@
 /dist
 .env
+*.d.ts
+*.d.ts.map

--- a/packages/ckan/package.json
+++ b/packages/ckan/package.json
@@ -33,6 +33,7 @@
     "c8": "^8.0.1",
     "mocha": "^10.2.0",
     "oxigraph": "^0.3.22",
-    "trifid-core": "^2.7.1"
+    "trifid-core": "^2.7.1",
+    "typescript": "5.3.3"
   }
 }

--- a/packages/ckan/package.json
+++ b/packages/ckan/package.json
@@ -5,7 +5,10 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "test": "c8 --reporter=lcov --reporter=text mocha"
+    "test": "c8 --reporter=lcov --reporter=text mocha",
+    "prebuild": "rimraf src/*.d.ts",
+    "build": "tsc",
+    "prepack": "npm run build"
   },
   "repository": {
     "type": "git",

--- a/packages/ckan/tsconfig.json
+++ b/packages/ckan/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  // Change this to match your project
+  "include": ["src/*.js"],
+  "compilerOptions": {
+    // Tells TypeScript to read JS files, as
+    // normally they are ignored as source files
+    "allowJs": true,
+    // Generate d.ts files
+    "declaration": true,
+    // This compiler run should
+    // only output d.ts files
+    "emitDeclarationOnly": true,
+    // Types should go next to the .js files
+    // "outDir": "dist",
+    // go to js file when using IDE functions like
+    // "Go to Definition" in VSCode
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext"
+  }
+}


### PR DESCRIPTION
I found that type declarations are not checked in CI. Also, the CKAN plugin did not have typescript set up at all

I'd like to merge this before #257 