### PR TITLE
Update some CKAN properties

### DIFF
--- a/.changeset/fluffy-pillows-dance.md
+++ b/.changeset/fluffy-pillows-dance.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": minor
+---
+
+Export `dcterms:relation` from source cube

--- a/.changeset/kind-apples-shout.md
+++ b/.changeset/kind-apples-shout.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": patch
+---
+
+Added `foaf:page` - dataset documentation

--- a/.changeset/pink-mails-jog.md
+++ b/.changeset/pink-mails-jog.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": major
+---
+
+Output [europa.eu themes](https://publications.europa.eu/resource/authority/data-theme) explicitly mapped using `schema:sameAs`. Themes without a mapping are not included in the output.

--- a/.changeset/seven-horses-brake.md
+++ b/.changeset/seven-horses-brake.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": major
+---
+
+Use new output for the `dcat:Distribution/dcterms:format`, linking to [europa.eu controlled vocabulary](https://publications.europa.eu/resource/authority/file-type)

--- a/packages/ckan/src/namespace.js
+++ b/packages/ckan/src/namespace.js
@@ -1,6 +1,6 @@
 // @ts-check
 import _rdf from '@zazuko/env'
 
-const { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf } = _rdf.ns
+const { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf, rdfs } = _rdf.ns
 
-export { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf }
+export { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf, rdfs }

--- a/packages/ckan/src/namespace.js
+++ b/packages/ckan/src/namespace.js
@@ -1,6 +1,6 @@
 // @ts-check
 import _rdf from '@zazuko/env'
 
-const { dcat, dcterms, rdf, schema, skos, vcard, xsd } = _rdf.ns
+const { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf } = _rdf.ns
 
-export { dcat, dcterms, rdf, schema, skos, vcard, xsd }
+export { dcat, dcterms, rdf, schema, skos, vcard, xsd, foaf }

--- a/packages/ckan/src/query.js
+++ b/packages/ckan/src/query.js
@@ -15,6 +15,7 @@ const datasetsQuery = (organizationId) => {
       ?o ?nestedP ?nestedO .
       ?copyright ${ns.schema.identifier} ?copyrightIdentifier .
       ?dataset ${ns.dcterms.accrualPeriodicity} ?accrualPeriodicity .
+      ?publisher ${ns.schema.name} ?publisherName .
     }
     WHERE {
       GRAPH ?graph {
@@ -41,6 +42,11 @@ const datasetsQuery = (organizationId) => {
 
         OPTIONAL {
           ?dataset ${ns.dcterms.accrualPeriodicity} ?accrualPeriodicity .
+        }
+
+        OPTIONAL {
+          ?dataset ${ns.dcterms.publisher} ?publisher .
+          ?publisher ${ns.schema.name} ?publisherName .
         }
       }
     }

--- a/packages/ckan/src/query.js
+++ b/packages/ckan/src/query.js
@@ -16,6 +16,7 @@ const datasetsQuery = (organizationId) => {
       ?copyright ${ns.schema.identifier} ?copyrightIdentifier .
       ?dataset ${ns.dcterms.accrualPeriodicity} ?accrualPeriodicity .
       ?publisher ${ns.schema.name} ?publisherName .
+      ?dataset ${ns.dcat.theme} ?euTheme .
     }
     WHERE {
       GRAPH ?graph {
@@ -48,6 +49,13 @@ const datasetsQuery = (organizationId) => {
           ?dataset ${ns.dcterms.publisher} ?publisher .
           ?publisher ${ns.schema.name} ?publisherName .
         }
+
+        OPTIONAL {
+          ?dataset ${ns.dcat.theme} ?theme .
+          ?theme ${ns.schema.sameAs} ?euTheme .
+        }
+
+        FILTER (?p != ${ns.dcat.theme})
       }
     }
   `

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -70,12 +70,17 @@ const toXML = (dataset) => {
             .filter(workExample => workExample.out(ns.schema.encodingFormat).terms.length > 0)
             .map(workExample => ({
               'dcat:Distribution': {
+                '@': { 'rdf:about': workExample.out(ns.schema.url).value },
                 'dcterms:issued': serializeTerm(dataset.out(ns.dcterms.issued)),
                 'dcat:mediaType': serializeTerm(workExample.out(ns.schema.encodingFormat)),
                 'dcat:accessURL': serializeTerm(workExample.out(ns.schema.url)),
                 'dcterms:title': serializeTerm(workExample.out(ns.schema.name)),
                 'dcterms:license': serializeTerm(copyright),
-                'dcterms:format': { '#': distributionFormatFromEncoding(workExample.out(ns.schema.encodingFormat)) },
+                'dcterms:format': {
+                  '@': {
+                    'rdf:resource': distributionFormatFromEncoding(workExample.out(ns.schema.encodingFormat)),
+                  },
+                },
               },
             }))
 
@@ -257,13 +262,13 @@ const distributionFormatFromEncoding = (encodingPointer) => {
 
   switch (encoding) {
     case 'text/html': {
-      return 'HTML'
+      return 'http://publications.europa.eu/resource/authority/file-type/HTML'
     }
     case 'application/sparql-query': {
-      return 'SERVICE'
+      return 'http://publications.europa.eu/resource/authority/file-type/SPARQLQ'
     }
     default: {
-      return 'UNKNOWN'
+      return `https://www.iana.org/assignments/media-types/${encoding}`
     }
   }
 }

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -28,6 +28,7 @@ const toXML = (dataset) => {
       dcat: prefixes.dcat,
       dcterms: prefixes.dcterms,
       vcard: prefixes.vcard,
+      foaf: prefixes.foaf,
     },
   }, {
     'rdf:RDF': {
@@ -80,8 +81,8 @@ const toXML = (dataset) => {
 
           const publishers = dataset.out(ns.dcterms.publisher)
             .map(publisher => ({
-              'rdf:Description': {
-                'rdfs:label': publisher.value,
+              'foaf:Organization': {
+                'foaf:name': publisher.value,
               },
             }))
 

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -80,11 +80,25 @@ const toXML = (dataset) => {
             }))
 
           const publishers = dataset.out(ns.dcterms.publisher)
-            .map(publisher => ({
-              'foaf:Organization': {
-                'foaf:name': publisher.value,
-              },
-            }))
+            .map(publisher => {
+              const attr = {}
+              /** @type {string | string[]} */
+              let name = publisher.value
+
+              if (isNamedNode(publisher)) {
+                attr['rdf:about'] = publisher.value
+                if (publisher.out(ns.schema.name).values.length > 0) {
+                  name = publisher.out(ns.schema.name).values
+                }
+              }
+
+              return {
+                'foaf:Organization': {
+                  '@': attr,
+                  'foaf:name': name,
+                },
+              }
+            })
 
           // Datasets contain a mix of legacy (DC) frequencies and new (EU) frequencies.
           // The query makes sure we get both legacy and new ones, we only

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -74,7 +74,7 @@ const toXML = (dataset) => {
                 'dcat:mediaType': serializeTerm(workExample.out(ns.schema.encodingFormat)),
                 'dcat:accessURL': serializeTerm(workExample.out(ns.schema.url)),
                 'dcterms:title': serializeTerm(workExample.out(ns.schema.name)),
-                'dcterms:rights': serializeTerm(copyright),
+                'dcterms:license': serializeTerm(copyright),
                 'dcterms:format': { '#': distributionFormatFromEncoding(workExample.out(ns.schema.encodingFormat)) },
               },
             }))

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -89,7 +89,7 @@ const toXML = (dataset) => {
           // Datasets contain a mix of legacy (DC) frequencies and new (EU) frequencies.
           // The query makes sure we get both legacy and new ones, we only
           // provide the new ones to CKAN, by converting legacy ones if needed.
-          const legacyFreqPrefix = 'http://publications.europa.eu/resource/authority/frequency/'
+          const euFreqPrefix = 'http://publications.europa.eu/resource/authority/frequency/'
           const accrualPeriodicity = dataset.out(ns.dcterms.accrualPeriodicity)
             .map((t) => {
               if (!t.term || !t.term.value) {
@@ -99,7 +99,7 @@ const toXML = (dataset) => {
               t.term.value = convertLegacyFrequency(t.term.value)
               return t
             })
-            .filter(({ term }) => term.value.startsWith(legacyFreqPrefix))
+            .filter(({ term }) => term.value.startsWith(euFreqPrefix))
 
           return {
             'dcat:Dataset': {

--- a/packages/ckan/src/xml.js
+++ b/packages/ckan/src/xml.js
@@ -139,6 +139,7 @@ const toXML = (dataset) => {
               'dcterms:temporal': serializeTerm(dataset.out(ns.dcterms.temporal)),
               'dcterms:accrualPeriodicity': serializeTerm(accrualPeriodicity),
               'dcat:distribution': distributions,
+              'foaf:page': serializeTerm(dataset.out(ns.foaf.page)),
             },
           }
         }).filter(Boolean),

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -203,5 +203,16 @@ describe('@zazuko/trifid-plugin-ckan', () => {
       ])
       expect(themes).to.have.length(3)
     })
+
+    it('should get temporal PeriodOfTime', async () => {
+      const themes = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcterms:temporal')
+
+      const expected = await parser.parseStringPromise(`
+        <dcterms:PeriodOfTime>
+          <schema:startDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-01-01</schema:startDate>
+          <schema:endDate rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2024-12-31</schema:endDate>
+        </dcterms:PeriodOfTime>`)
+      expect(themes).to.containSubset(expected)
+    })
   })
 })

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -191,5 +191,16 @@ describe('@zazuko/trifid-plugin-ckan', () => {
 
       expect(landingPage.$['rdf:resource']).to.eq('https://agrarmarktdaten.admin.ch')
     })
+
+    it('should use mapped themes', () => {
+      const themes = xpath.find(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme')
+        .map(theme => theme.$['rdf:resource'])
+
+      expect(themes).to.contain.all.members([
+        'http://publications.europa.eu/resource/authority/data-theme/AGRI',
+        'http://publications.europa.eu/resource/authority/data-theme/GOVE',
+        'http://publications.europa.eu/resource/authority/data-theme/ECON',
+      ])
+    })
   })
 })

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -201,6 +201,7 @@ describe('@zazuko/trifid-plugin-ckan', () => {
         'http://publications.europa.eu/resource/authority/data-theme/GOVE',
         'http://publications.europa.eu/resource/authority/data-theme/ECON',
       ])
+      expect(themes).to.have.length(3)
     })
   })
 })

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -102,6 +102,12 @@ describe('@zazuko/trifid-plugin-ckan', () => {
         </foaf:Organization>`)
         expect(publisher).to.containSubset(expected)
       })
+
+      it('should get landing page resource', () => {
+        const landingPage = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:landingPage')
+
+        expect(landingPage).to.eq('https://example.com/')
+      })
     })
 
     it('should convert legacy frequency to EU frequency if possible', async () => {
@@ -178,6 +184,12 @@ describe('@zazuko/trifid-plugin-ckan', () => {
           <foaf:name>Bundesamt für Landwirtschaft</foaf:name>
         </foaf:Organization>`)
       expect(publisher).to.containSubset(expected)
+    })
+
+    it('should get landing page resource', () => {
+      const landingPage = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:landingPage')
+
+      expect(landingPage.$['rdf:resource']).to.eq('https://agrarmarktdaten.admin.ch')
     })
   })
 })

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -106,7 +106,7 @@ describe('@zazuko/trifid-plugin-ckan', () => {
       it('should get landing page resource', () => {
         const landingPage = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:landingPage')
 
-        expect(landingPage).to.eq('https://example.com/')
+        expect(landingPage.$['rdf:resource']).to.eq('https://example.com/')
       })
     })
 

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -43,6 +43,9 @@ const createTrifidInstance = async () => {
 
 describe('@zazuko/trifid-plugin-ckan', () => {
   let trifidListener
+  const parser = new xml.Parser({
+    explicitArray: false,
+  })
 
   beforeEach(async () => {
     const trifidInstance = await createTrifidInstance()
@@ -71,15 +74,34 @@ describe('@zazuko/trifid-plugin-ckan', () => {
       strictEqual(body, expectedResult)
     })
 
-    it('should get a basic result for a known organization', async () => {
-      const ckanUrl = `${getListenerURL(trifidListener)}/ckan?organization=http://example.com/my-org`
+    describe('example organization', () => {
+      let res
+      let xmlText
+      let xmlBody
 
-      const res = await fetch(ckanUrl)
-      const body = await res.text()
-      const expectedResult = await readFile(new URL('./support/basic-result.xml', import.meta.url), 'utf8')
+      beforeEach(async () => {
+        const ckanUrl = `${getListenerURL(trifidListener)}/ckan?organization=http://example.com/my-org`
+        res = await fetch(ckanUrl)
+        xmlText = await res.text()
+        xmlBody = await parser.parseStringPromise(xmlText)
+      })
 
-      strictEqual(res.status, 200)
-      strictEqual(body, expectedResult)
+      it('should get a basic result for a known organization', async () => {
+        const expectedResult = await readFile(new URL('./support/basic-result.xml', import.meta.url), 'utf8')
+
+        strictEqual(res.status, 200)
+        strictEqual(xmlText, expectedResult)
+      })
+
+      it('should take publisher at face value', async () => {
+        const publisher = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcterms:publisher')
+
+        const expected = await parser.parseStringPromise(`
+        <foaf:Organization>
+          <foaf:name>http://example.com/my-org</foaf:name>
+        </foaf:Organization>`)
+        expect(publisher).to.containSubset(expected)
+      })
     })
 
     it('should convert legacy frequency to EU frequency if possible', async () => {
@@ -129,16 +151,16 @@ describe('@zazuko/trifid-plugin-ckan', () => {
   })
 
   describe('BLW tests', () => {
-    const parser = new xml.Parser({
-      explicitArray: false,
+    let xmlBody
+
+    beforeEach(async () => {
+      const ckanUrl = `${getListenerURL(trifidListener)}/ckan?organization=https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw`
+      const res = await fetch(ckanUrl)
+      xmlBody = await parser.parseStringPromise(await res.text())
     })
 
     it('should get a correct contactPoint', async () => {
-      const ckanUrl = `${getListenerURL(trifidListener)}/ckan?organization=https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw`
-
-      const res = await fetch(ckanUrl)
-      const body = await parser.parseStringPromise(await res.text())
-      const contactPoint = xpath.evalFirst(body, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:contactPoint')
+      const contactPoint = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:contactPoint')
 
       const expected = await parser.parseStringPromise(`
         <vcard:Organization>
@@ -146,6 +168,16 @@ describe('@zazuko/trifid-plugin-ckan', () => {
           <vcard:hasEmail rdf:resource="mailto:marktanalysen@blw.admin.ch"/>
         </vcard:Organization>`)
       expect(contactPoint).to.containSubset(expected)
+    })
+
+    it('should get structured publisher', async () => {
+      const publisher = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcterms:publisher')
+
+      const expected = await parser.parseStringPromise(`
+        <foaf:Organization rdf:about="https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw">
+          <foaf:name>Bundesamt für Landwirtschaft</foaf:name>
+        </foaf:Organization>`)
+      expect(publisher).to.containSubset(expected)
     })
   })
 })

--- a/packages/ckan/test/ckan.test.js
+++ b/packages/ckan/test/ckan.test.js
@@ -214,5 +214,11 @@ describe('@zazuko/trifid-plugin-ckan', () => {
         </dcterms:PeriodOfTime>`)
       expect(themes).to.containSubset(expected)
     })
+
+    it('should build correct distribution format', async () => {
+      const format = xpath.evalFirst(xmlBody, '//rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution/dcat:Distribution/dcterms:format')
+
+      expect(format.$['rdf:resource']).to.eq('http://publications.europa.eu/resource/authority/file-type/SPARQLQ')
+    })
   })
 })

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -33,7 +33,7 @@
         <dcterms:relation>
           <rdf:Description rdf:about="http://www.bafu.admin.ch/laerm/index.html"/>
         </dcterms:relation>
-        <dcat:landingPage>https://example.com/</dcat:landingPage>
+        <dcat:landingPage rdf:resource="https://example.com/"/>
         <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
         <foaf:page rdf:resource="https://example.com/docs"/>
       </dcat:Dataset>

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -14,6 +14,11 @@
         <dcterms:description xml:lang="it">Dataset 1 - Description</dcterms:description>
         <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-10-31</dcterms:issued>
         <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#dateTime">2023-10-31T15:15:15Z</dcterms:modified>
+        <dcterms:publisher>
+          <foaf:Organization rdf:about="http://example.com/my-org">
+            <foaf:name>http://example.com/my-org</foaf:name>
+          </foaf:Organization>
+        </dcterms:publisher>
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
         <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
       </dcat:Dataset>

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -20,6 +20,7 @@
           </foaf:Organization>
         </dcterms:publisher>
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
+        <dcat:landingPage>https://example.com/</dcat:landingPage>
         <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
       </dcat:Dataset>
     </dcat:dataset>

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -20,6 +20,19 @@
           </foaf:Organization>
         </dcterms:publisher>
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
+        <dcterms:relation>
+          <rdf:Description rdf:about="https://www.fedlex.admin.ch/eli/cc/1998/3033_3033_3033/de#art_27">
+            <rdfs:label>legal_basis</rdfs:label>
+          </rdf:Description>
+        </dcterms:relation>
+        <dcterms:relation>
+          <rdf:Description rdf:about="http://www.bafu.admin.ch/laerm/index.html?lang=de">
+            <rdfs:label>Webseite des BAFU</rdfs:label>
+          </rdf:Description>
+        </dcterms:relation>
+        <dcterms:relation>
+          <rdf:Description rdf:about="http://www.bafu.admin.ch/laerm/index.html"/>
+        </dcterms:relation>
         <dcat:landingPage>https://example.com/</dcat:landingPage>
         <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
         <foaf:page rdf:resource="https://example.com/docs"/>

--- a/packages/ckan/test/support/basic-result.xml
+++ b/packages/ckan/test/support/basic-result.xml
@@ -22,6 +22,7 @@
         <dcterms:creator rdf:resource="http://example.com/my-org"/>
         <dcat:landingPage>https://example.com/</dcat:landingPage>
         <dcterms:accrualPeriodicity rdf:resource="http://publications.europa.eu/resource/authority/frequency/IRREG"/>
+        <foaf:page rdf:resource="https://example.com/docs"/>
       </dcat:Dataset>
     </dcat:dataset>
     <dcat:dataset>

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -139,7 +139,12 @@
     <https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Production_Quantity_Month/observation/> ;
   cube:observationConstraint
     <https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Production_Quantity_Month/shape> ;
-  admin:euDataTheme theme:AGRI, theme:ECON .
+  admin:euDataTheme theme:AGRI, theme:ECON ;
+  dcterms:temporal [
+    a dcterms:PeriodOfTime ;
+    schema:startDate "2024-01-01"^^xsd:date ;
+    schema:endDate "2024-12-31"^^xsd:date ;
+  ] .
 
 _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 a schema:ContactPoint, vcard:Organization ;
   dcterms:title "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen" ;

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -1,3 +1,4 @@
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 @base <http://example.com/> .
 @prefix schema: <http://schema.org/> .
@@ -44,6 +45,13 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   dcterms:publisher <http://example.com/my-org> ;
   dcat:landingPage "https://example.com/" ;
   foaf:page <https://example.com/docs> ;
+  dcterms:relation <http://www.bafu.admin.ch/laerm/index.html> ;
+  dcterms:relation <http://www.bafu.admin.ch/laerm/index.html?lang=de> ;
+  dcterms:license <https://www.fedlex.admin.ch/eli/cc/1998/3033_3033_3033/de#art_27> ;
+.
+
+<http://www.bafu.admin.ch/laerm/index.html?lang=de>
+  rdfs:label "Webseite des BAFU" ;
 .
 
 <dataset2>

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -1,3 +1,4 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
 @base <http://example.com/> .
 @prefix schema: <http://schema.org/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -42,6 +43,7 @@
   schema:version "1"^^xsd:integer ;
   dcterms:publisher <http://example.com/my-org> ;
   dcat:landingPage "https://example.com/" ;
+  foaf:page <https://example.com/docs> ;
 .
 
 <dataset2>

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -43,7 +43,7 @@ PREFIX foaf: <http://xmlns.com/foaf/0.1/>
   schema:description "Dataset 1 - Description"@de ;
   schema:version "1"^^xsd:integer ;
   dcterms:publisher <http://example.com/my-org> ;
-  dcat:landingPage "https://example.com/" ;
+  dcat:landingPage <https://example.com/> ;
   foaf:page <https://example.com/docs> ;
   dcterms:relation <http://www.bafu.admin.ch/laerm/index.html> ;
   dcterms:relation <http://www.bafu.admin.ch/laerm/index.html?lang=de> ;

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -155,3 +155,15 @@ _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 a schema:ContactPoint, 
  # schema:name "Office fédéral de l'agriculture"@fr ;
  # schema:name "Ufficio federale dell'agricoltura"@it ;
 .
+
+category:administration
+  schema:sameAs <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
+.
+
+category:agriculture
+  schema:sameAs <http://publications.europa.eu/resource/authority/data-theme/AGRI> ;
+.
+
+category:national-economy
+  schema:sameAs <http://publications.europa.eu/resource/authority/data-theme/ECON> ;
+.

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -41,6 +41,7 @@
   schema:description "Dataset 1 - Description"@de ;
   schema:version "1"^^xsd:integer ;
   dcterms:publisher <http://example.com/my-org> ;
+  dcat:landingPage "https://example.com/" ;
 .
 
 <dataset2>
@@ -114,11 +115,7 @@
   schema:publisher <https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw> ;
   schema:contactPoint _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 ;
   schema:datePublished "2024-02-01"^^xsd:date ;
-  dcat:landingPage
-    <https://agrarmarktdaten.admin.ch>,
-    <https://donnees-agrimarche.admin.ch>,
-    <https://dati-agrimercato.admin.ch>,
-    <https://agrimarketdata.admin.ch> ;
+  dcat:landingPage <https://agrarmarktdaten.admin.ch> ;
   schema:workExample
     <https://ld.admin.ch/application/opendataswiss>,
     <https://ld.admin.ch/application/visualize>,

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -40,7 +40,8 @@
   schema:description "Dataset 1 - Description"@it ;
   schema:description "Dataset 1 - Description"@de ;
   schema:version "1"^^xsd:integer ;
-  .
+  dcterms:publisher <http://example.com/my-org> ;
+.
 
 <dataset2>
   rdf:type schema:Dataset ;
@@ -71,7 +72,7 @@
   schema:description "Dataset 2 - Description"@it ;
   schema:description "Dataset 2 - Description"@de ;
   schema:version "1"^^xsd:integer ;
-  .
+.
 
 #########################################
 #
@@ -149,3 +150,11 @@ _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 a schema:ContactPoint, 
   schema:email "marktanalysen@blw.admin.ch" ;
   vcard:fn "Bundesamt für Landwirtschaft, Fachbereich Marktanalysen" ;
   vcard:hasEmail <mailto:marktanalysen@blw.admin.ch> .
+
+<https://register.ld.admin.ch/opendataswiss/org/bundesamt-fur-landwirtschaft-blw>
+  rdf:type schema:Organization ;
+  schema:name "Bundesamt für Landwirtschaft"@de ;
+ # schema:name "Federal Office for Agriculture"@en ;
+ # schema:name "Office fédéral de l'agriculture"@fr ;
+ # schema:name "Ufficio federale dell'agricoltura"@it ;
+.


### PR DESCRIPTION
Re #280

Properties of `dcat:Dataset`:
  - `publisher`: import format changed ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-publisher
  - `theme`: new vocabulary to use ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-theme
  - `landing page`: import format changed ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-landing-page
  - `accrual periodicity`: import format changed ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-accrual-periodicity
  - `related resource`: mandatory for federal level, the legal basis must be indicated here ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-relation
  - `documentation`: new property ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-dataset-documentation

Properties of `dcat:Distribution`:
  - `license`: replaces `dct:rights` ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-distribution-license
  - `format`: use a Controlled Vocabulary (CV) ; see: https://handbook.opendata.swiss/de/content/glossar/bibliothek/dcat-ap-ch.html#dcat-distribution-format
  