### PR TITLE
refactor: explicitly annotated deprecated categories

### DIFF
--- a/.changeset/lazy-lemons-protect.md
+++ b/.changeset/lazy-lemons-protect.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-ckan": patch
+---
+
+Map old and new category identifiers to the new controled vocabulary required by DCAT-AP handbook

--- a/packages/ckan/src/query.js
+++ b/packages/ckan/src/query.js
@@ -52,7 +52,7 @@ const datasetsQuery = (organizationId) => {
 
         OPTIONAL {
           ?dataset ${ns.dcat.theme} ?theme .
-          ?theme ${ns.schema.sameAs} ?euTheme .
+          ?theme ${ns.schema.supersededBy}?/${ns.schema.sameAs} ?euTheme .
         }
 
         FILTER (?p != ${ns.dcat.theme})

--- a/packages/ckan/test/support/data.ttl
+++ b/packages/ckan/test/support/data.ttl
@@ -134,7 +134,7 @@
   dcterms:license <https://www.fedlex.admin.ch/eli/cc/1998/3033_3033_3033/de#art_27> ;
   dcterms:accrualPeriodicity <http://publications.europa.eu/resource/authority/frequency/MONTHLY> ;
   dcat:contactPoint _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 ;
-  dcat:theme category:administration, category:agriculture, category:national-economy, category:prices ;
+  dcat:theme category:gove, category:agriculture, category:national-economy, category:wrong ;
   cube:observationSet
     <https://agriculture.ld.admin.ch/foag/cube/MilkDairyProducts/Production_Quantity_Month/observation/> ;
   cube:observationConstraint
@@ -156,11 +156,15 @@ _:genid2de581ad199db849c2a2500f49babdf0072d0b695fb815fb9 a schema:ContactPoint, 
  # schema:name "Ufficio federale dell'agricoltura"@it ;
 .
 
-category:administration
+category:gove
   schema:sameAs <http://publications.europa.eu/resource/authority/data-theme/GOVE> ;
 .
 
 category:agriculture
+  schema:supersededBy category:agri ;
+.
+
+category:agri
   schema:sameAs <http://publications.europa.eu/resource/authority/data-theme/AGRI> ;
 .
 


### PR DESCRIPTION
Related to https://gitlab.ldbar.ch/pipelines/open-data-swiss/-/merge_requests/10, I also change the code to handle the explicit `schema:supersededBy` which separates old and new categories