### PR TITLE
Fix wrong value for rewrite query parameter

### DIFF
--- a/.changeset/fifty-pillows-carry.md
+++ b/.changeset/fifty-pillows-carry.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": patch
+---
+
+Fix an issue with the rewrite query parameter, where it was assuming that undefined value was equal to 'true'

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -93,7 +93,14 @@ const factory = async (trifid) => {
 
         let currentRewriteConfig = rewriteConfig
         if (allowRewriteToggle) {
-          const rewriteConfigValueFromQuery = `${request.query.rewrite}` || rewriteConfigValue
+          let rewriteConfigValueFromQuery = rewriteConfigValue
+          if (`${request.query.rewrite}` === 'false') {
+            rewriteConfigValueFromQuery = false
+          } else if (`${request.query.rewrite}` === 'true') {
+            rewriteConfigValueFromQuery = true
+          } else {
+            rewriteConfigValueFromQuery = rewriteConfigValue
+          }
           currentRewriteConfig = sparqlGetRewriteConfiguration(rewriteConfigValueFromQuery, datasetBaseUrl)
         }
         const { rewrite: rewriteValue, iriOrigin } = currentRewriteConfig
@@ -107,7 +114,7 @@ const factory = async (trifid) => {
         let query = ''
         switch (request.method) {
           case 'GET':
-            query = request.query.query
+            query = request.query.query || ''
             break
           case 'POST':
             if (typeof request.body === 'string') {


### PR DESCRIPTION
This is fixing an issue with the rewrite query parameter, where it was assuming that an undefined value was equal to 'true' in all cases.