### PR TITLE
Internal `render` function requires the request as first argument

### DIFF
--- a/.changeset/curvy-poems-sort.md
+++ b/.changeset/curvy-poems-sort.md
@@ -1,0 +1,5 @@
+---
+"trifid-core": major
+---
+
+The `render` function requires the request as first argument.

--- a/.changeset/ninety-birds-type.md
+++ b/.changeset/ninety-birds-type.md
@@ -1,0 +1,9 @@
+---
+"@zazuko/trifid-markdown-content": patch
+"@zazuko/trifid-entity-renderer": patch
+"trifid-plugin-graph-explorer": patch
+"trifid-plugin-yasgui": patch
+"trifid-plugin-spex": patch
+---
+
+Internally use the new `render` function, that takes the `request` as first argument.

--- a/packages/core/lib/handlers/notFound.js
+++ b/packages/core/lib/handlers/notFound.js
@@ -35,6 +35,7 @@ const factory = async ({ render }) => {
       case 'html':
         reply.type('text/html').send(
           await render(
+            request,
             `${currentDir}/../../views/404.hbs`,
             {
               url: request.url,

--- a/packages/core/lib/templateEngine.js
+++ b/packages/core/lib/templateEngine.js
@@ -36,7 +36,7 @@ const forceRefresh = false
 /**
  * Render a view.
  *
- * @typedef {(templatePath: string, context: Record<string, any>, options: Record<string, any>) => Promise<string>} RenderFunction
+ * @typedef {(request: import('fastify').FastifyRequest & { session: Map<string, any> }, templatePath: string, context: Record<string, any>, options: Record<string, any>) => Promise<string>} RenderFunction
  */
 
 /**
@@ -103,12 +103,15 @@ const templateEngine = async (defaultOptions, locals) => {
   /**
    * @type {RenderFunction}
    */
-  const render = async (templatePath, context, options = {}) => {
+  const render = async (request, templatePath, context, options = {}) => {
+    const session = request ? Object.fromEntries(request.session.entries()) : {}
     const template = await resolveTemplate(templatePath)
     const localsObject = Object.fromEntries(locals.entries())
+    const mergedSession = merge(session, context.session)
     const mergedLocals = merge(localsObject, context.locals)
     const mergedContext = merge({}, context)
     mergedContext.locals = mergedLocals
+    mergedContext.session = mergedSession
     const body = template(mergedContext)
 
     const renderedOptions = merge({}, mergedContext, templateOptions, options)

--- a/packages/core/plugins/view.js
+++ b/packages/core/plugins/view.js
@@ -36,11 +36,11 @@ const factory = async (trifid) => {
     routeHandler: async () => {
       /**
        * Route handler.
-       * @param {import('fastify').FastifyRequest} _request Request.
+       * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
        * @param {import('fastify').FastifyReply} reply Reply.
        */
-      const handler = async (_request, reply) => {
-        reply.status(200).type('text/html').send(await render(path, { ...context }, options))
+      const handler = async (request, reply) => {
+        reply.status(200).type('text/html').send(await render(request, path, { ...context }, options))
       }
       return handler
     },

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -63,7 +63,7 @@
  * @property {import('pino').Logger} logger The logger instance.
  * @property {import('fastify').FastifyInstance & {locals: Map<string, any>}} server The Fastify server instance.
  * @property {Object.<string, any>} config The Trifid configuration.
- * @property {(templatePath: string, context: Object.<string, any>, options?: Object.<string, any>) => Promise<string>} render The render function.
+ * @property {(request: import('fastify').FastifyRequest & { session: Map<string, any> }, templatePath: string, context: Object.<string, any>, options?: Object.<string, any>) => Promise<string>} render The render function.
  * @property {TrifidQuery} query The SPARQL query function.
  * @property {import('node:events').EventEmitter} trifidEvents The Trifid events emitter.
  * @property {(name: string, fn: import('handlebars').HelperDelegate) => void} registerTemplateHelper Register a template helper, that can be used by the template engine.

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -135,7 +135,7 @@ const factory = async (trifid) => {
     routeHandler: async () => {
       /**
        * Route handler.
-       * @param {import('fastify').FastifyRequest} request Request.
+       * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
@@ -225,7 +225,7 @@ const factory = async (trifid) => {
           )
           const metadata = await metadataProvider(request, { dataset })
 
-          reply.type('text/html').send(await render(entityTemplatePath, {
+          reply.type('text/html').send(await render(request, entityTemplatePath, {
             dataset: entityHtml,
             locals: {},
             entityLabel,

--- a/packages/graph-explorer/index.js
+++ b/packages/graph-explorer/index.js
@@ -61,7 +61,7 @@ const factory = async (trifid) => {
     routeHandler: async () => {
       /**
        * Route handler.
-       * @param {import('fastify').FastifyRequest} request Request.
+       * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
@@ -75,6 +75,7 @@ const factory = async (trifid) => {
         }
 
         const content = await render(
+          request,
           view,
           {
             // Just forward all the config as a string

--- a/packages/markdown-content/src/index.js
+++ b/packages/markdown-content/src/index.js
@@ -240,12 +240,12 @@ const factory = async (trifid) => {
 
         /**
          * Route handler for the specific content.
-         * @param {import('fastify').FastifyRequest} _request Request.
+         * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
          * @param {import('fastify').FastifyReply} reply Reply.
          * @returns {Promise<void>}
          */
-        const routeHandler = async (_request, reply) => {
-          return reply.type('text/html').send(await render(defaultValue('template', entry, template), {
+        const routeHandler = async (request, reply) => {
+          return reply.type('text/html').send(await render(request, defaultValue('template', entry, template), {
             content: locals.get(LOCALS_PLUGIN_KEY)?.[namespace]?.[item.name] || '',
           }))
         }

--- a/packages/spex/index.js
+++ b/packages/spex/index.js
@@ -49,7 +49,7 @@ const createPlugin = async (server, config, render) => {
 
   /**
    * Route handler.
-   * @param {import('fastify').FastifyRequest} request Request.
+   * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
    * @param {import('fastify').FastifyReply} reply Reply.
    */
   const handler = async (request, reply) => {
@@ -69,6 +69,7 @@ const createPlugin = async (server, config, render) => {
     ).toString()
 
     const content = await render(
+      request,
       config.template,
       {
         options: JSON.stringify(spexOptions),

--- a/packages/yasgui/index.js
+++ b/packages/yasgui/index.js
@@ -52,7 +52,7 @@ const trifidFactory = async (trifid) => {
     routeHandler: async () => {
       /**
        * Route handler.
-       * @param {import('fastify').FastifyRequest} request Request.
+       * @param {import('fastify').FastifyRequest & { session: Map<string, any> }} request Request.
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
@@ -69,6 +69,7 @@ const trifidFactory = async (trifid) => {
         const endpointUrl = new URL(endpoint, fullUrl)
 
         const content = await render(
+          request,
           view,
           {
             endpointUrl: endpointUrl.toString(),


### PR DESCRIPTION
This change allows the renderer to get information about the session.
This is required to properly support multilingual instances, for example.