### PR TITLE
`locals` should use cookies path set to `/`

### DIFF
--- a/.changeset/wise-flies-know.md
+++ b/.changeset/wise-flies-know.md
@@ -1,0 +1,5 @@
+---
+"trifid-core": patch
+---
+
+The locals plugins should use the cookies path set as `/`.

--- a/packages/core/plugins/locals.js
+++ b/packages/core/plugins/locals.js
@@ -4,8 +4,6 @@
 const factory = async (trifid) => {
   const { logger, server } = trifid
 
-  const locals = server.locals
-
   const defaultLanguage = 'en'
   const supportedLanguages = ['en', 'fr', 'de', 'it']
 
@@ -27,7 +25,7 @@ const factory = async (trifid) => {
     const langQuery = request.query.lang || ''
     if (langQuery && supportedLanguages.includes(langQuery)) {
       logger.debug(`set default language to '${langQuery}'`)
-      reply.setCookie('i18n', langQuery, { maxAge: oneMonthMilliseconds })
+      reply.setCookie('i18n', langQuery, { maxAge: oneMonthMilliseconds, path: '/' })
       session.set('currentLanguage', langQuery)
     }
 


### PR DESCRIPTION
For multilingual instances, it was setting a cookie only on the current page.
This was a strange behavior in terms of UX.