### PR TITLE
Add `i18n` cookie to requests made to the SPARQL endpoint

### DIFF
--- a/.changeset/two-rats-bow.md
+++ b/.changeset/two-rats-bow.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+Send `i18n` cookie to requests made to the SPARQL endpoint to avoid languages issues.

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -227,7 +227,6 @@ const factory = async (trifid) => {
 
           reply.type('text/html').send(await render(request, entityTemplatePath, {
             dataset: entityHtml,
-            locals: {},
             entityLabel,
             entityUrl,
             metadata,

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -145,6 +145,11 @@ const factory = async (trifid) => {
           return reply.callNotFound()
         }
 
+        // To avoid any languge issues, we will forward the i18n cookie to the SPARQL endpoint
+        const queryHeaders = {
+          cookie: `i18n=${request.session.get('currentLanguage') || 'en'}; Path=/; SameSite=Lax; Secure; HttpOnly`,
+        }
+
         // Get the expected format from the Accept header or from the `format` query parameter
         const acceptHeader = getAcceptHeader(request)
 
@@ -220,6 +225,7 @@ const factory = async (trifid) => {
               dataset,
               rewriteResponse,
               replaceIri,
+              headers: queryHeaders,
               entityRoot: rewriteValue ? iri.replace(datasetBaseUrl, iriOrigin(iriUrlString)) : iri,
             },
           )

--- a/packages/entity-renderer/renderer/entity.js
+++ b/packages/entity-renderer/renderer/entity.js
@@ -35,7 +35,7 @@ const toBoolean = (val) => {
  * Render HTML.
  */
 const createEntityRenderer = ({ options = {}, logger, query }) => {
-  return async (req, { dataset, rewriteResponse, replaceIri, entityRoot }) => {
+  return async (req, { dataset, rewriteResponse, replaceIri, entityRoot, headers }) => {
     const currentLanguage = req.session.get('currentLanguage') || req.session.get('defaultLanguage') || 'en'
     const rendererConfig = { ...DEFAULTS, ...options }
 
@@ -113,6 +113,7 @@ const createEntityRenderer = ({ options = {}, logger, query }) => {
       const labelLoader = new LabelLoader({
         ...options.labelLoader,
         query,
+        headers,
         replaceIri,
         rewriteResponse,
         logger,

--- a/packages/entity-renderer/renderer/labels/labelLoader.js
+++ b/packages/entity-renderer/renderer/labels/labelLoader.js
@@ -23,11 +23,14 @@ class LabelLoader {
       concurrency,
       timeout,
       logger,
+      headers,
     } = options
 
     this.query = query
     this.replaceIri = replaceIri
     this.rewriteResponse = rewriteResponse
+
+    this.headers = headers
 
     this.labelNamespaces = labelNamespace ? [labelNamespace] : labelNamespaces
     this.chunkSize = chunkSize || 30
@@ -90,7 +93,7 @@ CONSTRUCT {
     ?uri schema:name ?label
     VALUES ?uri { ${uris} }
   }
-}`, { ask: false, rewriteResponse: this.rewriteResponse })
+}`, { ask: false, rewriteResponse: this.rewriteResponse, headers: this.headers })
     // Make sure the Content-Type is lower case and without parameters (e.g. charset)
     const fixedContentType = response.contentType.split(';')[0].trim().toLocaleLowerCase()
     const quadStream = parsers.import(fixedContentType, response.response)


### PR DESCRIPTION
For each request made to the SPARQL endpoint, a `i18n` cookie that contains the value of the current language will be sent.

This is helping to prevent some issues for multilingual instances.