### PR TITLE
Add support for `application/sparql-query` content type

### DIFF
--- a/.changeset/mighty-items-behave.md
+++ b/.changeset/mighty-items-behave.md
@@ -1,0 +1,5 @@
+---
+"trifid-core": patch
+---
+
+Add support for `application/sparql-query` content type

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -78,6 +78,20 @@ const trifid = async (config, additionalPlugins = {}) => {
     ...serverOptions,
   })
 
+  // Add support for `application/sparql-query` content type
+  server.addContentTypeParser('application/sparql-query', (_request, payload, done) => {
+    const data = []
+    payload.on('data', (chunk) => data.push(chunk))
+    payload.on('end', () => {
+      try {
+        const parsed = data.join('')
+        done(null, parsed)
+      } catch (err) {
+        done(err, undefined)
+      }
+    })
+  })
+
   // This can be used to pass data from multiple plugins
   /** @type {Map<string, any>} */
   const trifidLocals = new Map()


### PR DESCRIPTION
Add support for `application/sparql-query` content type.

This allows queries to be sent directly as the body of an HTTP request.