### PR TITLE
Query quads

### DIFF
--- a/.changeset/beige-lemons-hear.md
+++ b/.changeset/beige-lemons-hear.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+Try to get quads from the store, in order to get the graph name.

--- a/.changeset/thirty-steaks-ring.md
+++ b/.changeset/thirty-steaks-ring.md
@@ -1,0 +1,5 @@
+---
+"trifid": patch
+---
+
+Upgrade dependencies

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -170,7 +170,7 @@ const factory = async (trifid) => {
 
         // Check if the IRI exists in the dataset
         const askQuery = isContainer ? mergedConfig.containerExistsQuery : mergedConfig.resourceExistsQuery
-        const exists = await query(replaceIriInQuery(askQuery, iri), { ask: true })
+        const exists = await query(replaceIriInQuery(askQuery, iri), { ask: true, headers: queryHeaders })
         if (!exists) {
           return reply.callNotFound()
         }
@@ -200,6 +200,10 @@ const factory = async (trifid) => {
           const entity = await query(replaceIriInQuery(describeQuery, iri), {
             ask: false,
             rewriteResponse,
+            headers: {
+              ...queryHeaders,
+              accept: 'application/n-quads',
+            },
           })
           const entityContentType = entity.contentType || 'application/n-triples'
           const entityStream = entity.response


### PR DESCRIPTION
Querying quads from the entity renderer allow getting the right graph names, so that they can be displayed on the dereferenced entity.