### PR TITLE
New `formats` configuration field for sparql-proxy

### DIFF
--- a/.changeset/eighty-mirrors-pump.md
+++ b/.changeset/eighty-mirrors-pump.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": minor
+---
+
+Add a `formats` configuration field, to manually configure the list of allowed formats that can be provided as query parameter. The SPARQL endpoint will need to support the specified formats.

--- a/packages/sparql-proxy/README.md
+++ b/packages/sparql-proxy/README.md
@@ -29,4 +29,13 @@ plugins:
       rewrite: false # Rewrite by default
       rewriteQuery: true # Allow rewriting the query (in case of rewriting)
       rewriteResults: true # Allow rewriting the results (in case of rewriting)
+
+      # Configure formats, that can be used as `format` query parameter
+      formats:
+        ttl: "text/turtle"
+        jsonld: "application/ld+json"
+        xml: "application/rdf+xml"
+        nt: "application/n-triples"
+        trig: "application/trig"
+        csv: "text/csv"
 ```

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -13,6 +13,7 @@ const defaultConfiguration = {
   rewrite: false, // Rewrite by default
   rewriteQuery: true, // Allow rewriting the query
   rewriteResults: true, // Allow rewriting the results
+  formats: {},
 }
 
 /**
@@ -63,6 +64,7 @@ const factory = async (trifid) => {
        * @typedef {Object} QueryString
        * @property {string} [query] The SPARQL query.
        * @property {string} [rewrite] Should the query and the results be rewritten?
+       * @property {string} [format] The format of the results.
        */
 
       /**
@@ -142,7 +144,10 @@ const factory = async (trifid) => {
         logger.debug(`Received query${rewriteValue ? ' (rewritten)' : ''}:\n${query}`)
 
         try {
-          const acceptHeader = request.headers.accept || 'application/sparql-results+json'
+          let acceptHeader = request.headers.accept || 'application/sparql-results+json'
+          if (request.query.format) {
+            acceptHeader = options.formats[request.query.format] || acceptHeader
+          }
           const headers = {
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: acceptHeader,

--- a/packages/trifid/instances/docker-sparql/config.yaml
+++ b/packages/trifid/instances/docker-sparql/config.yaml
@@ -60,3 +60,10 @@ plugins:
       endpointUrl: env:SPARQL_ENDPOINT_URL
       username: env:SPARQL_ENDPOINT_USERNAME
       password: env:SPARQL_ENDPOINT_PASSWORD
+      formats:
+        ttl: "text/turtle"
+        jsonld: "application/ld+json"
+        xml: "application/rdf+xml"
+        nt: "application/n-triples"
+        trig: "application/trig"
+        csv: "text/csv"


### PR DESCRIPTION
This allows users to specify a `format` query parameter to force the endpoint to deliver the response in a particular format.

The SPARQL endpoint should be able to support the requested format.