### PR TITLE
Set default timeout to 3min for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,8 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 3
+
     strategy:
       matrix:
         node-version:


### PR DESCRIPTION
Tests should be run fast.
If they take more than 3 minutes, it's an issue.