### PR TITLE
Disable node 18 for tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 18
           - 20
         package:
           - name: "@zazuko/trifid-plugin-ckan"


### PR DESCRIPTION
Jobs for tests using Node 18 seems to be in trouble, and we are using too many jobs in parallel.