### PR TITLE
Configure `defaultQuery` for YASGUI

### DIFF
--- a/.changeset/rare-forks-hear.md
+++ b/.changeset/rare-forks-hear.md
@@ -1,0 +1,11 @@
+---
+"trifid-plugin-yasgui": minor
+---
+
+It is now possible to configure the default SPARQL query to use in each new YASGUI tab, by configuring the `defaultQuery` configuration field.
+
+This feature is useful to provide a starting point for users who are not familiar with SPARQL queries and want to explore the data available in the SPARQL endpoint.
+
+You can define the default query in order to show a specific set of triples, or to show a specific number of triples, or to show a specific set of properties, etc. based on your data model.
+
+It can be also useful to also include common prefixes in the default query, so users can start writing their queries without having to remember the prefixes.

--- a/packages/yasgui/README.md
+++ b/packages/yasgui/README.md
@@ -24,6 +24,13 @@ plugins:
     config:
       endpointUrl: https://example.com/query
       urlShortener: https://example.com/api/v1/shorten
+      defaultQuery: |
+        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+        SELECT * WHERE {
+          ?sub ?pred ?obj .
+        } LIMIT 10
       # …other configuration fields
 ```
 
@@ -35,3 +42,4 @@ The following options are supported:
 - `urlShortener`: URL of an URL Shortener service. It will be called like this (assuming `urlShortener` is `https://example.com/api/v1/shorten`): `https://example.com/api/v1/shorten?url=url-to-your-query` and should return a short URL as plain text (`https://example.com/s/x8Z1a`). If `urlShortener` is not defined, the short URL feature will be disabled in YASGUI.
 - `template`: Path to an alternative template (default: `views/yasgui.hbs`)
 - `catalog`: Array of SPARQL endpoints that will be shown in the YASGUI interface.
+- `defaultQuery`: Default query that will be shown in the YASGUI interface.

--- a/packages/yasgui/index.js
+++ b/packages/yasgui/index.js
@@ -9,7 +9,7 @@ const currentDir = dirname(fileURLToPath(import.meta.url))
 /** @type {import('../core/types/index.js').TrifidPlugin} */
 const trifidFactory = async (trifid) => {
   const { config, render, server } = trifid
-  const { template, endpointUrl, urlShortener, catalog } = config
+  const { template, endpointUrl, urlShortener, catalog, defaultQuery } = config
 
   const endpoint = endpointUrl || '/query'
   const view = !template ? `${currentDir}/views/yasgui.hbs` : template
@@ -18,6 +18,8 @@ const trifidFactory = async (trifid) => {
   if (!Array.isArray(catalogOption)) {
     throw new Error('"catalog" option must be an array')
   }
+
+  const defaultQueryOption = defaultQuery || ''
 
   // Serve static files for YASGUI
   const yasguiPath = resolve('@zazuko/yasgui/build/', import.meta.url)
@@ -85,6 +87,7 @@ const trifidFactory = async (trifid) => {
             endpointUrl: endpointUrl.toString(),
             catalogueEndpoints,
             urlShortener,
+            defaultQuery: JSON.stringify(defaultQueryOption),
           },
           { title: 'YASGUI' },
         )

--- a/packages/yasgui/views/yasgui.hbs
+++ b/packages/yasgui/views/yasgui.hbs
@@ -47,12 +47,16 @@
   {{/if}}
 
   <script>
+    const defaultQuery = {{{ defaultQuery }}}
     const catalogueEndpoints = [...new Set(JSON.parse('{{{ catalogueEndpoints }}}'))]
     Yasgui.defaults.requestConfig.endpoint = '{{ endpointUrl }}'
     Yasgui.defaults.endpointCatalogueOptions.getData = () => {
       return catalogueEndpoints.map((endpoint) => {
         return { endpoint }
       })
+    }
+    if (defaultQuery) {
+      Yasgui.Yasqe.defaults.value = defaultQuery
     }
     const yasgui = new Yasgui(document.getElementById('yasgui'), config)
   </script>


### PR DESCRIPTION
As requested in #334, it can be useful to be able to configure the default query for the YASGUI plugin.

This PR adds this feature.