### PR TITLE
Use `mimeparse` to parse Accept headers

### DIFF
--- a/.changeset/fuzzy-dingos-hide.md
+++ b/.changeset/fuzzy-dingos-hide.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+Uses `mimeparse` module to support complex Accept headers

--- a/package-lock.json
+++ b/package-lock.json
@@ -10188,6 +10188,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimeparse": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz",
+      "integrity": "sha512-jiuAsJJY4c0oF97oHKic9nva2y1QF2yhYJG3LXLys//f8SNQ89eFuGZ29z62Z29CAY4endJS6zFiKUtURFErog==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -15244,7 +15252,7 @@
     },
     "packages/ckan": {
       "name": "@zazuko/trifid-plugin-ckan",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "UNLICENSED",
       "dependencies": {
         "@tpluscode/rdf-string": "^1.3.0",
@@ -15262,7 +15270,7 @@
         "chai-subset": "^1.6.0",
         "mocha": "^10.4.0",
         "rimraf": "^5.0.5",
-        "trifid-core": "^4.0.0",
+        "trifid-core": "^4.0.5",
         "trifid-handler-fetch": "^3.0.0",
         "typescript": "^5.4.5",
         "xml2js": "^0.6.2",
@@ -15271,7 +15279,7 @@
     },
     "packages/core": {
       "name": "trifid-core",
-      "version": "4.0.4",
+      "version": "4.0.5",
       "license": "MIT",
       "dependencies": {
         "@fastify/accepts": "^4.3.0",
@@ -15313,7 +15321,7 @@
     },
     "packages/entity-renderer": {
       "name": "@zazuko/trifid-entity-renderer",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@lit-labs/ssr": "^3.1.9",
@@ -15323,15 +15331,16 @@
         "@zazuko/prefixes": "^2.1.0",
         "@zazuko/rdf-entity-webcomponent": "^0.7.7",
         "lit": "^3.1.3",
+        "mimeparse": "^0.1.4",
         "p-queue": "^8.0.1",
-        "trifid-core": "^4.0.2"
+        "trifid-core": "^4.0.5"
       },
       "devDependencies": {
         "@rdfjs/types": "^1.1.0",
         "c8": "^9.1.0",
         "mocha": "^10.4.0",
         "trifid-handler-fetch": "^3.0.0",
-        "trifid-plugin-yasgui": "^3.0.2"
+        "trifid-plugin-yasgui": "^3.1.0"
       }
     },
     "packages/graph-explorer": {
@@ -15383,7 +15392,7 @@
     },
     "packages/iiif": {
       "name": "@zazuko/trifid-plugin-iiif",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@tpluscode/rdf-string": "^1.3.0",
@@ -15396,7 +15405,7 @@
         "@types/jsonld": "^1.5.13",
         "c8": "^9.1.0",
         "mocha": "^10.4.0",
-        "trifid-core": "^4.0.3"
+        "trifid-core": "^4.0.5"
       }
     },
     "packages/markdown-content": {
@@ -15424,11 +15433,11 @@
     },
     "packages/sparql-proxy": {
       "name": "@zazuko/trifid-plugin-sparql-proxy",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "string-replace-stream": "^0.0.2",
-        "trifid-core": "^4.0.0"
+        "trifid-core": "^4.0.5"
       },
       "devDependencies": {
         "@types/node": "^20.12.7"
@@ -15450,18 +15459,18 @@
       }
     },
     "packages/trifid": {
-      "version": "5.0.2",
+      "version": "5.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@zazuko/trifid-entity-renderer": "^1.0.3",
-        "@zazuko/trifid-plugin-sparql-proxy": "^2.0.1",
+        "@zazuko/trifid-entity-renderer": "^1.0.4",
+        "@zazuko/trifid-plugin-sparql-proxy": "^2.1.0",
         "commander": "^12.0.0",
-        "trifid-core": "^4.0.0",
+        "trifid-core": "^4.0.5",
         "trifid-handler-fetch": "^3.0.0",
         "trifid-plugin-graph-explorer": "^2.0.2",
         "trifid-plugin-i18n": "^3.0.0",
         "trifid-plugin-spex": "^2.0.2",
-        "trifid-plugin-yasgui": "^3.0.2"
+        "trifid-plugin-yasgui": "^3.1.0"
       },
       "bin": {
         "trifid": "server.js"
@@ -15469,7 +15478,7 @@
     },
     "packages/yasgui": {
       "name": "trifid-plugin-yasgui",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^7.0.3",
@@ -15480,7 +15489,7 @@
       "devDependencies": {
         "c8": "^9.1.0",
         "mocha": "^10.4.0",
-        "trifid-core": "^4.0.3"
+        "trifid-core": "^4.0.5"
       }
     }
   }

--- a/packages/entity-renderer/package.json
+++ b/packages/entity-renderer/package.json
@@ -27,6 +27,7 @@
     "@zazuko/prefixes": "^2.1.0",
     "@zazuko/rdf-entity-webcomponent": "^0.7.7",
     "lit": "^3.1.3",
+    "mimeparse": "^0.1.4",
     "p-queue": "^8.0.1",
     "trifid-core": "^4.0.5"
   },


### PR DESCRIPTION
This uses the `mimeparse` module to support complex Accept headers.

Improvement for #362, as suggested by @ktk.