### PR TITLE
Faster health checks for the Docker image

### DIFF
--- a/.changeset/nine-fireants-press.md
+++ b/.changeset/nine-fireants-press.md
@@ -1,0 +1,5 @@
+---
+"trifid": patch
+---
+
+Faster default health checks on `/healthz` by using the Docker image

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,9 @@ WORKDIR /app/packages/trifid
 
 ENTRYPOINT ["tini", "--", "/app/packages/trifid/server.js"]
 
-HEALTHCHECK CMD wget -q -O- http://localhost:8080/healthz
+HEALTHCHECK \
+  --interval=5s \
+  --timeout=30s \
+  --start-period=60s \
+  --retries=5 \
+  CMD wget -q -O- http://127.0.0.1:8080/healthz


### PR DESCRIPTION
This improves the default health check configured for the Docker image, in order to mark it as healthy faster.

If a specific Trifid instance needs more time to be started, it can always be possible to override this configuration.