### PR TITLE
Send Server-Timing responses for SPARQL query responses

### DIFF
--- a/.changeset/late-papayas-smell.md
+++ b/.changeset/late-papayas-smell.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": minor
+---
+
+Returns `Server-Timing` as response header containing the duration of the request to the configured endpoint.

--- a/.changeset/sweet-ducks-worry.md
+++ b/.changeset/sweet-ducks-worry.md
@@ -1,0 +1,5 @@
+---
+"trifid-handler-fetch": minor
+---
+
+Returns `Server-Timing` as response header containing the duration of the request to perform.

--- a/packages/handler-fetch/index.js
+++ b/packages/handler-fetch/index.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { Worker } from 'node:worker_threads'
+import { performance } from 'node:perf_hooks'
 import { v4 as uuidv4 } from 'uuid'
 import { waitForVariableToBeTrue } from './lib/utils.js'
 
@@ -160,8 +161,12 @@ export const factory = async (trifid) => {
         logger.debug(`Received query: ${query}`)
 
         try {
+          const start = performance.now()
           const { response, contentType } = await handleQuery(query)
+          const end = performance.now()
+          const duration = end - start
           reply.type(contentType)
+          reply.header('Server-Timing', `handler-fetch;dur=${duration};desc="Query execution time"`)
           logger.debug(`Sending the following ${contentType} response:\n${response}`)
           reply.status(200).send(response)
         } catch (error) {


### PR DESCRIPTION
Returns `Server-Timing` as response header containing the duration of the request to perform, for the sparql-proxy and for the handler-fetch Trifid plugins.