### PR TITLE
Run tests using Node 22 also

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         node-version:
           - 20
+          - 22
 
     steps:
       - name: Checkout
@@ -42,14 +43,20 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version:
+          - 20
+          - 22
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up NodeJS
+      - name: Set up NodeJS ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install dependencies


### PR DESCRIPTION
Since Node 22 will be the new LTS version soon (end of October), it could be great to make sure that everything is already ready for that version.

This PR is enabling the run of the tests on Node 22 in addition of the current Node 20.