### PR TITLE
[sparql-proxy] Configure query log level

### DIFF
--- a/.changeset/gold-peaches-smile.md
+++ b/.changeset/gold-peaches-smile.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": minor
+---
+
+It is now possible to configure the log level of the queries by using the `queryLogLevel` configuration option.

--- a/packages/sparql-proxy/README.md
+++ b/packages/sparql-proxy/README.md
@@ -38,4 +38,7 @@ plugins:
         nt: "application/n-triples"
         trig: "application/trig"
         csv: "text/csv"
+
+      # Configure the log level for the queries
+      queryLogLevel: debug # Log level for the queries
 ```


### PR DESCRIPTION
This PR allows the configuration of the query log level for the `sparql-proxy` Trifid plugin.