### PR TITLE
[handler-fetch] Configure query log level

### DIFF
--- a/.changeset/gorgeous-apes-prove.md
+++ b/.changeset/gorgeous-apes-prove.md
@@ -1,0 +1,5 @@
+---
+"trifid-handler-fetch": minor
+---
+
+It is now possible to configure the log level of the queries by using the `queryLogLevel` configuration option.

--- a/packages/handler-fetch/README.md
+++ b/packages/handler-fetch/README.md
@@ -41,6 +41,7 @@ plugins:
 - `baseIRI`: the base IRI to use to resolve the relative IRIs in the serialization.
 - `graphName`: for triple serialization formats, the name of the named graph the triple should be loaded to.
 - `unionDefaultGraph`: for triple serialization formats, if the triples should be loaded to the default graph or to the named graph specified in `graphName`. This impacts also the need or not to query a specific graph in SPARQL queries. Defaults to `false`.
+- `queryLogLevel`: the log level for the queries. Defaults to `debug`.
 
 Supported formats:
 


### PR DESCRIPTION
This PR allows the configuration of the query log level for the `handler-fetch` Trifid plugin.

It is done in a similar way as for the `sparql-proxy` (work done in #446).