### PR TITLE
[core] Add `server.logFormat` configuration option

### DIFF
--- a/.changeset/fresh-avocados-reply.md
+++ b/.changeset/fresh-avocados-reply.md
@@ -1,0 +1,5 @@
+---
+"trifid-core": minor
+---
+
+Introduce a `server.logFormat` configuration option, to either output JSON or pretty-formated logs.

--- a/packages/core/config.yaml
+++ b/packages/core/config.yaml
@@ -7,6 +7,7 @@ server:
   listener:
     port: 8080
   logLevel: debug
+  logFormat: pretty
 
 globals:
   value: config

--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -12,6 +12,7 @@ import handler from './lib/config/handler.js'
 import {
   defaultHost,
   defaultLogLevel,
+  defaultLogFormat,
   defaultPort,
 } from './lib/config/default.js'
 import pluginsAssembler from './lib/plugins/assembler.js'
@@ -57,6 +58,9 @@ const trifid = async (config, additionalPlugins = {}) => {
 
   const serverOptions = fullConfig?.server?.options || {}
 
+  // Template configuration
+  const template = fullConfig?.template || {}
+
   // Dynamic server configuration
   const portFromConfig = fullConfig?.server?.listener?.port
   const port = (portFromConfig === 0 || portFromConfig === '0') ? 0 : (portFromConfig || defaultPort)
@@ -65,18 +69,19 @@ const trifid = async (config, additionalPlugins = {}) => {
 
   // Logger configuration
   const logLevel = fullConfig?.server?.logLevel || defaultLogLevel
-
-  // Template configuration
-  const template = fullConfig?.template || {}
-
-  // Custom logger instance
-  const logger = pino({
+  const logFormat = fullConfig?.server?.logFormat || defaultLogFormat
+  const loggerConfig = {
     name: 'trifid-core',
     level: logLevel,
-    transport: {
+  }
+  if (logFormat === 'pretty') {
+    loggerConfig.transport = {
       target: 'pino-pretty',
-    },
-  })
+    }
+  }
+
+  // Custom logger instance
+  const logger = pino(loggerConfig)
 
   const server = fastify({
     logger: false,

--- a/packages/core/lib/config/default.js
+++ b/packages/core/lib/config/default.js
@@ -5,3 +5,4 @@ export const maxDepth = 50
 export const defaultPort = 8080
 export const defaultHost = '0.0.0.0'
 export const defaultLogLevel = 'info'
+export const defaultLogFormat = 'pretty'

--- a/packages/core/lib/config/schema.json
+++ b/packages/core/lib/config/schema.json
@@ -65,6 +65,13 @@
             "silent"
           ]
         },
+        "logFormat": {
+          "type": "string",
+          "enum": [
+            "json",
+            "pretty"
+          ]
+        },
         "options": {
           "type": "object",
           "additionalProperties": true

--- a/packages/core/types/index.js
+++ b/packages/core/types/index.js
@@ -25,6 +25,7 @@
  * @property {string} [server.listener.host] The host to listen on.
  * @property {number|string} [server.listener.port] The port to listen on.
  * @property {"fatal"|"error"|"warn"|"info"|"debug"|"trace"|"silent"} [server.logLevel] The log level.
+ * @property {"pretty"|"json"} [server.logFormat] The log format.
  * @property {Object.<string, any>} [server.options] Server options.
  * @property {Object.<string, any>} [globals] Global settings.
  * @property {Object.<string, any>} [template] Template settings.

--- a/packages/entity-renderer/examples/config/trifid.yaml
+++ b/packages/entity-renderer/examples/config/trifid.yaml
@@ -2,6 +2,7 @@
 
 server:
   logLevel: debug
+  logFormat: pretty
 
 globals:
   datasetBaseUrl: http://localhost:3000/


### PR DESCRIPTION
This adds the following configuration option: `server.logFormat`.

It can take one of the following value:
- `pretty` (default): use [`pino-pretty`](https://github.com/pinojs/pino-pretty) to display logs in a pretty format, ideal for development
- `json`: great for production, as it is easier to parse by using some scripts or other tools