### PR TITLE
Add `enableSchemaUrlRedirect` config option

### DIFF
--- a/.changeset/lovely-months-mix.md
+++ b/.changeset/lovely-months-mix.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": minor
+---
+
+Add `enableSchemaUrlRedirect` configuration option (experimental).

--- a/packages/entity-renderer/README.md
+++ b/packages/entity-renderer/README.md
@@ -93,6 +93,8 @@ The default redirect query supports `http://www.w3.org/2011/http#` and `http://w
   Each rule is either a string or an object with the following properties:
   - `find`: the string to find
   - `replace`: the string to replace with (optional, the default value will be the current hostname)
+- `enableSchemaUrlRedirect` (experimental): If set to `true`, the plugin will perform a redirect if the URI contains a `schema:URL` predicate poiting to a resource of type `xsd:anyURI`.
+  The default value is `false`.
 
 ## Run an example instance
 

--- a/packages/entity-renderer/README.md
+++ b/packages/entity-renderer/README.md
@@ -93,7 +93,7 @@ The default redirect query supports `http://www.w3.org/2011/http#` and `http://w
   Each rule is either a string or an object with the following properties:
   - `find`: the string to find
   - `replace`: the string to replace with (optional, the default value will be the current hostname)
-- `enableSchemaUrlRedirect` (experimental): If set to `true`, the plugin will perform a redirect if the URI contains a `schema:URL` predicate poiting to a resource of type `xsd:anyURI`.
+- `enableSchemaUrlRedirect` (experimental): If set to `true`, the plugin will perform a redirect if the URI contains a `schema:URL` predicate pointing to a resource of type `xsd:anyURI`.
   The default value is `false`.
 
 ## Run an example instance

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -262,8 +262,9 @@ const factory = async (trifid) => {
               .filter(({ object }) => object.datatype.value === 'xsd:anyURI')
               .map(({ object }) => urls.push(object.value))
             if (urls.length > 0) {
-              logger.debug(`Redirecting to ${urls[0]}`)
-              return reply.redirect(urls[0])
+              const redirectUrl = urls[0]
+              logger.debug(`Redirecting to ${redirectUrl}`)
+              return reply.redirect(redirectUrl)
             }
           }
 


### PR DESCRIPTION
This adds a `enableSchemaUrlRedirect` configuration option.

If set to `true`, the plugin will perform a redirect if the URI contains a `schema:URL` predicate pointing to a resource of type `xsd:anyURI`.

The default value is `false`.