### PR TITLE
Add stream support back

### DIFF
--- a/.changeset/proud-donkeys-exercise.md
+++ b/.changeset/proud-donkeys-exercise.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": patch
+---
+
+Enable stream support back

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -4,7 +4,7 @@ import { Readable } from 'node:stream'
 import { performance } from 'node:perf_hooks'
 import { Worker } from 'node:worker_threads'
 import { sparqlGetRewriteConfiguration } from 'trifid-core'
-// import replaceStream from 'string-replace-stream'
+import replaceStream from 'string-replace-stream'
 import rdf from '@zazuko/env-node'
 
 const defaultConfiguration = {
@@ -250,16 +250,17 @@ const factory = async (trifid) => {
 
           const contentType = response.headers.get('content-type')
 
-          let responseStream = await response.text() // response.body
+          /** @type {any} */
+          let responseStream = response.body
           if (rewriteResponse && options.rewriteResults) {
-            responseStream = responseStream.replaceAll(rewriteResponse.origin, rewriteResponse.replacement)
-            // responseStream = Readable
-            //   .from(responseStream)
-            //   .pipe(replaceStream(
-            //     rewriteResponse.origin,
-            //     rewriteResponse.replacement,
-            //   ))
+            responseStream = Readable
+              .from(responseStream)
+              .pipe(replaceStream(
+                rewriteResponse.origin,
+                rewriteResponse.replacement,
+              ))
           }
+          responseStream = Readable.fromWeb(responseStream)
 
           reply
             .status(response.status)


### PR DESCRIPTION
With the previous release, we were hit by an issue that prevented the `sparql-proxy` plugin to use streams if compression was requested, and we temporarily replaced them with awaited strings.

The issue with this was that responses were a bit slower as the plugin was waiting to get the full data from the endpoint before sending it to the client.
Also, in terms of memory usage, it was not ideal.

Using the workaround given in https://github.com/fastify/fastify-compress/issues/309#issuecomment-2303563647 seems to solve the issue.

There was just an issue in terms of types that were reported ; as it behaves correctly, I just disabled the type error by using a cast to `any` for the `responseStream` variable.