### PR TITLE
Improve the Map plugin icon

### DIFF
--- a/.changeset/cuddly-colts-camp.md
+++ b/.changeset/cuddly-colts-camp.md
@@ -1,0 +1,5 @@
+---
+"trifid-plugin-yasgui": patch
+---
+
+Improve the Map plugin icon

--- a/packages/yasgui/plugins/map.js
+++ b/packages/yasgui/plugins/map.js
@@ -88,7 +88,7 @@ class YasguiMap {
 
   getIcon () {
     const textIcon = document.createElement('div')
-    textIcon.innerText = '🌐'
+    textIcon.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-map-pin"><path d="M20 10c0 4.993-5.539 10.193-7.399 11.799a1 1 0 0 1-1.202 0C9.539 20.193 4 14.993 4 10a8 8 0 0 1 16 0"/><circle cx="12" cy="10" r="3"/></svg>'
     return textIcon
   }
 }


### PR DESCRIPTION
This improves the Map plugin icon.
It uses an SVG instead of the unicode character.
This delivers a more consistent look and feel across all kind of devices and operating systems.