### PR TITLE
Let the user disable schema url redirects if enabled

### DIFF
--- a/.changeset/tasty-ladybugs-retire.md
+++ b/.changeset/tasty-ladybugs-retire.md
@@ -1,0 +1,10 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+If `enableSchemaUrlRedirect` configuration option is set to `true`, the plugin is performing a redirect if the URI contains a `schema:URL` predicate pointing to a resource of type `xsd:anyURI` (already in place).
+
+The user can now disable this behavior by either:
+
+- setting the `disableSchemaUrlRedirect` query parameter to `true`
+- setting the `x-disable-schema-url-redirect` header to `true`

--- a/packages/entity-renderer/README.md
+++ b/packages/entity-renderer/README.md
@@ -95,6 +95,9 @@ The default redirect query supports `http://www.w3.org/2011/http#` and `http://w
   - `replace`: the string to replace with (optional, the default value will be the current hostname)
 - `enableSchemaUrlRedirect` (experimental): If set to `true`, the plugin will perform a redirect if the URI contains a `schema:URL` predicate pointing to a resource of type `xsd:anyURI`.
   The default value is `false`.
+  If enabled, the user can still disable this behavior by either:
+  - setting the `disableSchemaUrlRedirect` query parameter to `true`
+  - setting the `x-disable-schema-url-redirect` header to `true`
 
 ## Run an example instance
 

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -260,12 +260,16 @@ const factory = async (trifid) => {
           const dataset = await rdf.dataset().import(quadStream)
 
           if (mergedConfig.enableSchemaUrlRedirect && acceptHeader === 'text/html') {
+            const disabledSchemaUrlRedirect =
+              request.headers['x-disable-schema-url-redirect'] === 'true' ||
+              request.query.disableSchemaUrlRedirect === 'true'
+
             // Get all triples that have a schema:URL property with value of type xsd:anyURI
             const urls = []
             dataset.match(iriUrlString, rdf.ns.schema.URL)
               .filter(({ object }) => object.datatype.value === 'xsd:anyURI')
               .map(({ object }) => urls.push(object.value))
-            if (urls.length > 0) {
+            if (!disabledSchemaUrlRedirect && urls.length > 0) {
               const redirectUrl = urls[0]
               logger.debug(`Redirecting to ${redirectUrl}`)
               reply.redirect(redirectUrl)


### PR DESCRIPTION
If `enableSchemaUrlRedirect` configuration option is set to `true`, the plugin is performing a redirect if the URI contains a `schema:URL` predicate pointing to a resource of type `xsd:anyURI` (already in place).

The user can now disable this behavior by either:

- setting the `disableSchemaUrlRedirect` query parameter to `true`
- setting the `x-disable-schema-url-redirect` header to `true`