### PR TITLE
Migrate i18n to node test

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "test": "c8 --all --reporter=lcovonly mocha"
+    "test": "c8 --all --reporter=lcovonly --reporter=text node --test"
   },
   "author": "Zazuko GmbH",
   "license": "MIT",
@@ -28,7 +28,6 @@
   "devDependencies": {
     "@types/i18n": "^0.13.12",
     "c8": "^10.1.2",
-    "mocha": "^10.7.3",
     "trifid-core": "^5.0.0"
   },
   "publishConfig": {

--- a/packages/i18n/test/test.js
+++ b/packages/i18n/test/test.js
@@ -3,9 +3,9 @@
 import { strictEqual } from 'node:assert'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
+import { describe, it, afterEach } from 'node:test'
 
 import trifidCore from 'trifid-core'
-import { describe } from 'mocha'
 
 import trifidPluginFactory from '../index.js'
 


### PR DESCRIPTION
Migrate this simple i18n plugin to native node test runner.