### PR TITLE
Node 22

### DIFF
--- a/.changeset/grumpy-items-relate.md
+++ b/.changeset/grumpy-items-relate.md
@@ -1,0 +1,5 @@
+---
+"trifid": patch
+---
+
+Upgrade container base image from Node 20 to 22.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:20-alpine
+FROM docker.io/library/node:22-alpine
 
 EXPOSE 8080
 


### PR DESCRIPTION
Upgrade base image for the container image to v22 of Node.
Also use Node 22 in GitHub Actions.