### PR TITLE
Handle null requestPort

### DIFF
--- a/.changeset/funny-teachers-promise.md
+++ b/.changeset/funny-teachers-promise.md
@@ -1,0 +1,10 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+"trifid-plugin-graph-explorer": patch
+"@zazuko/trifid-plugin-sparql-proxy": patch
+"@zazuko/trifid-plugin-ckan": patch
+"@zazuko/trifid-plugin-iiif": patch
+"trifid-plugin-spex": patch
+---
+
+Fix `requestPort` value, to handle `null` cases and simplify the logic

--- a/packages/ckan/src/index.js
+++ b/packages/ckan/src/index.js
@@ -31,9 +31,9 @@ const factory = async (trifid) => {
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
-        let requestPort = `:${request.port}`
-        if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-          requestPort = ''
+        let requestPort = ''
+        if (request.port) {
+          requestPort = `:${request.port}`
         }
         const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
         const endpoint = new URL(configuredEndpoint, fullUrl)

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -180,9 +180,9 @@ const factory = async (trifid) => {
         const acceptHeader = getAcceptHeader(request)
 
         // Generate the IRI we expect
-        let requestPort = `:${request.port}`
-        if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-          requestPort = ''
+        let requestPort = ''
+        if (request.port) {
+          requestPort = `:${request.port}`
         }
         const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
         const iriUrl = new URL(fullUrl)

--- a/packages/graph-explorer/index.js
+++ b/packages/graph-explorer/index.js
@@ -65,9 +65,9 @@ const factory = async (trifid) => {
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
-        let requestPort = `:${request.port}`
-        if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-          requestPort = ''
+        let requestPort = ''
+        if (request.port) {
+          requestPort = `:${request.port}`
         }
         const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
         const fullUrlObject = new URL(fullUrl)

--- a/packages/iiif/index.js
+++ b/packages/iiif/index.js
@@ -39,9 +39,9 @@ const trifidFactory = async (trifid) => {
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
-        let requestPort = `:${request.port}`
-        if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-          requestPort = ''
+        let requestPort = ''
+        if (request.port) {
+          requestPort = `:${request.port}`
         }
         const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
         const fullUrlObject = new URL(fullUrl)

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -140,9 +140,9 @@ const factory = async (trifid) => {
        * @param {import('fastify').FastifyReply} reply Reply.
        */
       const handler = async (request, reply) => {
-        let requestPort = `:${request.port}`
-        if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-          requestPort = ''
+        let requestPort = ''
+        if (request.port) {
+          requestPort = `:${request.port}`
         }
         const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
         const fullUrlObject = new URL(fullUrl)

--- a/packages/spex/index.js
+++ b/packages/spex/index.js
@@ -53,9 +53,9 @@ const createPlugin = async (server, config, render) => {
    * @param {import('fastify').FastifyReply} reply Reply.
    */
   const handler = async (request, reply) => {
-    let requestPort = `:${request.port}`
-    if ((request.protocol === 'http' && requestPort === ':80') || (request.protocol === 'https' && requestPort === ':443')) {
-      requestPort = ''
+    let requestPort = ''
+    if (request.port) {
+      requestPort = `:${request.port}`
     }
     const fullUrl = `${request.protocol}://${request.hostname}${requestPort}${request.url}`
     const fullUrlObject = new URL(fullUrl)


### PR DESCRIPTION
Fix `requestPort` value, to handle `null` cases and simplify the logic.