### PR TITLE
Use standard `fetch` to shorten URLs

### DIFF
--- a/.changeset/odd-spiders-notice.md
+++ b/.changeset/odd-spiders-notice.md
@@ -1,0 +1,5 @@
+---
+"trifid-plugin-yasgui": patch
+---
+
+Use standard `fetch` to shorten URLs

--- a/packages/yasgui/views/yasgui.hbs
+++ b/packages/yasgui/views/yasgui.hbs
@@ -36,13 +36,16 @@
   {{#if urlShortener }}
   <script>
     config.yasqe = {
-      createShortLink: function(yasqe, longString) {
-        return yasqe.superagent
-          .post('{{ urlShortener }}')
-          .send({ url: longString })
-          .then(function(resp) {
-            return resp.text
-          });
+      createShortLink: (yasqe, longString) => {
+        return fetch('{{ urlShortener }}', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ url: longString })
+        }).then((resp) => {
+          return resp.text()
+        });
       }
     }
   </script>


### PR DESCRIPTION
Before it was using `superagent` included with Yasgui editor, which is now not included anymore.