### PR TITLE
sparql-proxy: remove tests on external resources

### DIFF
--- a/packages/sparql-proxy/test/index.test.js
+++ b/packages/sparql-proxy/test/index.test.js
@@ -191,28 +191,5 @@ describe('sparql-proxy', () => {
       // then
       expect(response.headers.get('content-type')).to.eq('text/turtle')
     })
-
-    context('against a real SPARQL endpoint', () => {
-      beforeEach(() => {
-        defaultTestConfig = {
-          endpointUrl: 'https://dbpedia.org/sparql',
-          serviceDescriptionTimeout: 10000,
-          // dbpedia does not do content negotiation 🙄
-          serviceDescriptionFormat: 'text/turtle',
-        }
-      })
-
-      it('should work', async () => {
-        // given
-        const url = await startTrifid()
-
-        // when
-        const response = await rdf.fetch(`${url}/query`)
-        const dataset = await response.dataset()
-
-        // then
-        expect(dataset).to.have.property('size').greaterThan(2)
-      }).timeout(10000)
-    })
   })
 })


### PR DESCRIPTION
Using tests on external resources can make the pipeline fail if the end resource is not available, which is not something we want.

I removed the tests in the `sparql-proxy` plugin that were targeting DBpedia.

Example of failed pipeline: https://github.com/zazuko/trifid/actions/runs/11886907613/job/33118804561