### PR TITLE
[README] Fix environment variables to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ You can use the following environment variables:
 - `TRIFID_CONFIG`: the configuration file to use (default value: [`instances/docker-sparql/config.yaml`](./packages/trifid/instances/docker-sparql/config.yaml), which enable the following environment variables)
 - `SPARQL_ENDPOINT_URL`: the SPARQL endpoint URL to use
 - `DATASET_BASE_URL`: the base URL to use to enable rewriting
-- `SPARQL_USER`: the user to use to authenticate against the SPARQL endpoint
-- `SPARQL_PASSWORD`: the password to use to authenticate against the SPARQL endpoint
+- `SPARQL_ENDPOINT_USERNAME`: the user to use to authenticate against the SPARQL endpoint
+- `SPARQL_ENDPOINT_PASSWORD`: the password to use to authenticate against the SPARQL endpoint
 
 If you want to use a file that contains your triples instead of a SPARQL endpoint, you can set `TRIFID_CONFIG` to [`instances/docker-fetch/config.yaml`](./packages/trifid/instances/docker-fetch/config.yaml), and you will be able to use the following environment variables to configure your instance:
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,6 @@ Here is the list of all packages that are maintained here:
 | [`trifid-plugin-spex`](./packages/spex)                          | [![](https://badge.fury.io/js/trifid-plugin-spex.svg)](https://npm.im/trifid-plugin-spex)                                   | SPEX plugin for Trifid            |
 | [`trifid-plugin-yasgui`](./packages/yasgui)                      | [![](https://badge.fury.io/js/trifid-plugin-yasgui.svg)](https://npm.im/trifid-plugin-yasgui)                               | YASGUI plugin for Trifid          |
 
-More to come as we gradually consolidate other, initially separate repositories.
-
 ## Support
 
 Issues & feature requests should be reported on [GitHub](https://github.com/zazuko/trifid).


### PR DESCRIPTION
The README was still showing very old default environment variable names.
This PR updates the README file to show the new one to use.

Thank you @tpluscode for reporting the issue!