### PR TITLE
Bump `@zazuko/yasgui` to 4.5.0

### DIFF
--- a/.changeset/cruel-worlds-juggle.md
+++ b/.changeset/cruel-worlds-juggle.md
@@ -1,0 +1,6 @@
+---
+"trifid-plugin-yasgui": patch
+"trifid": patch
+---
+
+Bump `@zazuko/yasgui` to 4.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -2453,21 +2453,6 @@
       "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.16",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
-      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.12.tgz",
-      "integrity": "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
@@ -3331,20 +3316,19 @@
       }
     },
     "node_modules/@zazuko/yasgui": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasgui/-/yasgui-4.4.3.tgz",
-      "integrity": "sha512-lcd40tzcjcWRHB+FhvDZIakMrBy+iig2YpgTigvr/TY9GPvGmPfRCGG6wlG+J3wKDfG1xkWhVYIuIYkAwa7sXw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasgui/-/yasgui-4.5.0.tgz",
+      "integrity": "sha512-eVFWMUlE7b5/yrE9eJ0jWg/eMV8tZVU4Agtdfy9OHvvxDxbh7xK+C3XQMgiAx30pmHaLO4qdBda6pdehL0nTAQ==",
       "license": "MIT",
       "dependencies": {
         "@tarekraafat/autocomplete.js": "^7.2.0",
-        "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.4.3",
-        "@zazuko/yasqe": "^4.4.3",
-        "@zazuko/yasr": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
+        "@zazuko/yasqe": "^4.5.0",
+        "@zazuko/yasr": "^4.5.0",
         "autosuggest-highlight": "^3.1.1",
         "blueimp-md5": "^2.12.0",
         "choices.js": "^9.0.1",
-        "dompurify": "^2.0.7",
+        "dompurify": "^3.2.4",
         "es6-object-assign": "^1.1.0",
         "jsuri": "^1.3.1",
         "lodash-es": "^4.17.15",
@@ -3352,33 +3336,22 @@
       }
     },
     "node_modules/@zazuko/yasgui-utils": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasgui-utils/-/yasgui-utils-4.4.3.tgz",
-      "integrity": "sha512-/kvP/eewMRpbuFw6qUPPsIQ0SbCQPTbWHGQLLPbpYllQqH50xgH5j7Cb5rytcyb9QuAzIsGs0T1qmfm6ZVCuqw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasgui-utils/-/yasgui-utils-4.5.0.tgz",
+      "integrity": "sha512-+m8Y33mNS51wBA+mN52sjtucyyKJB4ihkKaL+w6jtezEuO/DkDpwGpGywVYeXtnE5eW0XQOEPCFW/A/aXMnWyg==",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^22.5.4",
-        "dompurify": "^2.0.7",
+        "dompurify": "^3.2.4",
         "store": "^2.0.12"
       }
     },
-    "node_modules/@zazuko/yasgui-utils/node_modules/@types/node": {
-      "version": "22.13.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.9.tgz",
-      "integrity": "sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~6.20.0"
-      }
-    },
     "node_modules/@zazuko/yasqe": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasqe/-/yasqe-4.4.3.tgz",
-      "integrity": "sha512-h+Xl3VV8EK0WTcu9Vn48onkdojLwufnh6pxqJoXYxJijBziJVfw2GYzrcXqd5d6BXdzo8SWyDo8DBY1tf79h7A==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasqe/-/yasqe-4.5.0.tgz",
+      "integrity": "sha512-YqsCViZHQ3XuFw3147S4eogm/fY4mGIJeFbdSk+cgHhhGSUHrj1N0+vHw2QdNbgU1QsU6myXlHULhgXPFi5SuA==",
       "license": "MIT",
       "dependencies": {
-        "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
         "codemirror": "^5.51.0",
         "lodash-es": "^4.17.15",
         "query-string": "^6.10.1"
@@ -3388,23 +3361,22 @@
       }
     },
     "node_modules/@zazuko/yasr": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/yasr/-/yasr-4.4.3.tgz",
-      "integrity": "sha512-oXUki+3u0jE0tmKe+nNTm/Da7ubl02447QokAqgsS7yT/wFKZUMKbEYKmXME85AJ1Ziy5JArZVmTo6pWveembg==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/yasr/-/yasr-4.5.0.tgz",
+      "integrity": "sha512-gquSemhdoonYah7rxoI0AK9smza1Dbukb+GhMSR9OqsRlXxdRhTakEGynyd2ltXKVTPhEbSWgJXiDhcG0lanZA==",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
         "@json2csv/plainjs": "^7.0.4",
-        "@types/lodash-es": "^4.17.3",
-        "@zazuko/yasgui-utils": "^4.4.3",
-        "@zazuko/yasqe": "^4.4.3",
+        "@zazuko/yasgui-utils": "^4.5.0",
+        "@zazuko/yasqe": "^4.5.0",
         "codemirror": "^5.51.0",
         "colors": "^1.4.0",
         "column-resizer": "^1.4.0",
         "datatables.net": "^2.0.5",
         "datatables.net-dt": "^2.0.5",
-        "dompurify": "^2.0.7",
-        "jquery": "^3.5.0",
+        "dompurify": "^3.2.4",
+        "jquery": "^3.7.1",
         "lodash-es": "^4.17.15",
         "n3": "^1.3.5",
         "papaparse": "^5.3.1"
@@ -5538,10 +5510,13 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "license": "(MPL-2.0 OR Apache-2.0)"
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
+      "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
@@ -14541,6 +14516,7 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -15849,7 +15825,7 @@
     },
     "packages/spex": {
       "name": "trifid-plugin-spex",
-      "version": "2.2.3",
+      "version": "3.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/static": "^8.1.1",
@@ -15862,7 +15838,7 @@
       }
     },
     "packages/trifid": {
-      "version": "5.0.8",
+      "version": "5.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@zazuko/trifid-entity-renderer": "^1.4.0",
@@ -15872,7 +15848,7 @@
         "trifid-handler-fetch": "^3.3.3",
         "trifid-plugin-graph-explorer": "^2.1.0",
         "trifid-plugin-i18n": "^3.0.2",
-        "trifid-plugin-spex": "^2.2.0",
+        "trifid-plugin-spex": "^3.0.0",
         "trifid-plugin-yasgui": "^3.3.0"
       },
       "bin": {
@@ -15885,7 +15861,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@fastify/static": "^8.1.1",
-        "@zazuko/yasgui": "^4.4.3",
+        "@zazuko/yasgui": "^4.5.0",
         "import-meta-resolve": "^4.1.0"
       },
       "devDependencies": {

--- a/packages/yasgui/package.json
+++ b/packages/yasgui/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "@fastify/static": "^8.1.1",
-    "@zazuko/yasgui": "^4.4.3",
+    "@zazuko/yasgui": "^4.5.0",
     "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This bumps the `@zazuko/yasgui` module to 4.5.0.