### PR TITLE
Add support for empty `datasetBaseUrl` back

### DIFF
--- a/.changeset/green-seas-smoke.md
+++ b/.changeset/green-seas-smoke.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-entity-renderer": patch
+---
+
+Allow empty `datasetBaseUrl` configuration value

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -40,6 +40,10 @@ const factory = async (trifid) => {
    * @type {Map<string, { rewrite: boolean, replaceIri: (iri: string) => string, iriOrigin: (iri: string) => string, datasetBaseUrl: string }>}
    */
   const dbu = new Map()
+  if (datasetBaseUrls.length === 0) {
+    dbu.set('default', { rewrite: rewriteConfigValue, replaceIri: (iri) => iri, iriOrigin: (iri) => iri, datasetBaseUrl: '' })
+    logger.debug('No datasetBaseUrl provided, no rewriting will be done')
+  }
   datasetBaseUrls.forEach((value) => {
     const rewriteConfig = sparqlGetRewriteConfiguration(rewriteConfigValue, value)
     // Just to have all the fields explicitly defined

--- a/packages/entity-renderer/lib/base.js
+++ b/packages/entity-renderer/lib/base.js
@@ -29,7 +29,7 @@ export const checkSingleDatasetBaseUrl = (logger, datasetBaseUrl) => {
  * Check the dataset base URL, and make sure it returns an array.
  * Some hints are provided if the dataset base URL is not correctly formatted.
  * If the dataset base URL is an array, each value is checked.
- * If a value is empty, then an error is thrown.
+ * If there is no dataset base URL, an empty array is returned.
  *
  * @param {{warn: Function }} logger - The logger instance
  * @param {string | string[]} datasetBaseUrl - The dataset base URL
@@ -37,7 +37,7 @@ export const checkSingleDatasetBaseUrl = (logger, datasetBaseUrl) => {
  */
 export const checkDatasetBaseUrl = (logger, datasetBaseUrl) => {
   if (!datasetBaseUrl) {
-    throw new Error('No datasetBaseUrl provided')
+    return []
   }
 
   if (Array.isArray(datasetBaseUrl)) {

--- a/packages/entity-renderer/test/base.test.js
+++ b/packages/entity-renderer/test/base.test.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-import { strictEqual, deepStrictEqual, throws } from 'node:assert'
+import { strictEqual, deepStrictEqual, throws, doesNotThrow } from 'node:assert'
 import { afterEach, beforeEach, describe, it } from 'node:test'
 
 import { checkSingleDatasetBaseUrl, checkDatasetBaseUrl } from '../lib/base.js'
@@ -73,7 +73,7 @@ describe('lib/base', () => {
     })
 
     it('should throw on empty value', () => {
-      throws(() => checkDatasetBaseUrl(logger, ''))
+      doesNotThrow(() => checkDatasetBaseUrl(logger, ''))
     })
 
     it('should throw on array with an empty value', () => {


### PR DESCRIPTION
This just adds support for the previous behavior back, where it was possible to run Trifid without specifying a `databaseBaseUrl` value.