### PR TITLE
Experimental flag for QLever

### DIFF
--- a/.changeset/shaky-parks-slide.md
+++ b/.changeset/shaky-parks-slide.md
@@ -1,0 +1,5 @@
+---
+"trifid": patch
+---
+
+Upgrade some dependencies

--- a/.changeset/tame-poems-grin.md
+++ b/.changeset/tame-poems-grin.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": patch
+---
+
+A simple tweak so that we can have the sparql-proxy running on top of a QLever endpoint

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -10,6 +10,9 @@ import rdf from '@zazuko/env-node'
 import ReplaceStream from './lib/ReplaceStream.js'
 import { authBasicHeader, objectLength, isValidUrl } from './lib/utils.js'
 
+// TODO: remove this once QLever supports other formats (experimental flag that would be removed at any time)
+const engineMode = process.env.TRIFID_ENGINE_MODE || 'default'
+
 const defaultConfiguration = {
   endpointUrl: '',
   username: '',
@@ -316,6 +319,12 @@ const factory = async (trifid) => {
           if (request.query.format) {
             acceptHeader = options.formats[request.query.format] || acceptHeader
           }
+
+          // TODO: remove this tweak once QLever supports other formats
+          if (engineMode === 'qlever' && !acceptHeader.startsWith('application/sparql-results+json')) {
+            acceptHeader = 'text/turtle'
+          }
+
           const headers = {
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: acceptHeader,


### PR DESCRIPTION
This is a simple workaround to have Trifid being able to work over a QLever endpoint for now.

Note that the `TRIFID_ENGINE_MODE=qlever` is an experimental flag through environment variable and that it could be removed or have some breaking changes without releasing a major version.