### PR TITLE
Add `headers` option

### DIFF
--- a/.changeset/violet-corners-learn.md
+++ b/.changeset/violet-corners-learn.md
@@ -1,0 +1,5 @@
+---
+"@zazuko/trifid-plugin-sparql-proxy": minor
+---
+
+Add support for `headers` option, to allow sending custom headers to the endpoint

--- a/packages/sparql-proxy/README.md
+++ b/packages/sparql-proxy/README.md
@@ -23,19 +23,25 @@ plugins:
       # In case your endpoint requires authentication:
       username: admin
       password: secret
+      # headers: # Optional headers to be sent with each request
+      #   X-Custom-Header: "CustomValue"
 
       # # In case you want to add support for multiple endpoints
       # # Define the endpoints in the following way (the "default" endpoint is required)
-      # # The default endpoint value will override the endpointUrl, username and password values
+      # # The default endpoint value will override the endpointUrl, username, password and headers values
       # endpoints:
       #   default:
       #     endpointUrl: https://example.com/query
       #     username: admin1
-      #     password: secret2
+      #     password: secret1
+      #     headers:
+      #       X-Custom-Header: "CustomValueDefault"
       #   other:
       #     endpointUrl: https://example.com/other-query
       #     username: admin2
       #     password: secret2
+      #     headers:
+      #       X-Custom-Header: "CustomValueOther"
 
       # Rewriting configuration
       allowRewriteToggle: true # Allow the user to toggle the rewrite configuration using the `rewrite` query parameter, even if `rewrite` is set to false

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -17,6 +17,7 @@ const defaultConfiguration = {
   endpointUrl: '',
   username: '',
   password: '',
+  headers: {}, // Additional headers to send to the SPARQL endpoint
   endpoints: {},
   datasetBaseUrl: '',
   allowRewriteToggle: true, // Allow the user to toggle the rewrite configuration using the `rewrite` query parameter.
@@ -53,6 +54,7 @@ const factory = async (trifid) => {
       options.endpointUrl = options.endpoints.default.url || ''
       options.username = options.endpoints.default.username || ''
       options.password = options.endpoints.default.password || ''
+      options.headers = options.endpoints.default.headers || {}
     }
 
     // Support for multiple endpoints
@@ -67,9 +69,8 @@ const factory = async (trifid) => {
     )
   }
 
-  let authorizationHeader
   if (options.username && options.password) {
-    authorizationHeader = authBasicHeader(options.username, options.password)
+    options.headers.Authorization = authBasicHeader(options.username, options.password)
   }
 
   const datasetBaseUrl = options.datasetBaseUrl
@@ -81,7 +82,7 @@ const factory = async (trifid) => {
     endpointUrl: options.endpointUrl,
     username: options.username,
     password: options.password,
-    authorizationHeader,
+    headers: options.headers,
     datasetBaseUrl,
     allowRewriteToggle,
     rewriteConfigValue,
@@ -98,9 +99,9 @@ const factory = async (trifid) => {
         throw Error(`Missing endpoints.${endpointName}.url parameter`)
       }
 
-      let endpointAuthorizationHeader
+      const endpointHeaders = endpointConfig.headers || {}
       if (endpointConfig.username && endpointConfig.password) {
-        endpointAuthorizationHeader = authBasicHeader(endpointConfig.username, endpointConfig.password)
+        endpointHeaders.Authorization = authBasicHeader(endpointConfig.username, endpointConfig.password)
       }
 
       const endpointDatasetBaseUrl = endpointConfig.datasetBaseUrl || datasetBaseUrl
@@ -110,7 +111,7 @@ const factory = async (trifid) => {
         endpointUrl: endpointConfig.url || '',
         username: endpointConfig.username || '',
         password: endpointConfig.password || '',
-        authorizationHeader: endpointAuthorizationHeader,
+        headers: endpointHeaders,
         datasetBaseUrl: endpointDatasetBaseUrl,
         allowRewriteToggle: endpointConfig.allowRewriteToggle ?? allowRewriteToggle,
         rewriteConfigValue: endpointRewriteConfigValue,
@@ -137,7 +138,7 @@ const factory = async (trifid) => {
       endpointUrl: options.endpointUrl,
       serviceDescriptionTimeout: options.serviceDescriptionTimeout,
       serviceDescriptionFormat: options.serviceDescriptionFormat,
-      authorizationHeader,
+      headers: options.headers,
     },
   })
 
@@ -326,11 +327,9 @@ const factory = async (trifid) => {
           }
 
           const headers = {
+            ...endpoint.headers,
             'Content-Type': 'application/x-www-form-urlencoded',
             Accept: acceptHeader,
-          }
-          if (endpoint.authorizationHeader) {
-            headers.Authorization = endpoint.authorizationHeader
           }
 
           const start = performance.now()

--- a/packages/sparql-proxy/lib/fetchServiceDescription.js
+++ b/packages/sparql-proxy/lib/fetchServiceDescription.js
@@ -1,10 +1,10 @@
 import rdf from '@zazuko/env-node'
 
-const fetchServiceDescription = async (endpointUrl, { format, authorization }) => {
+const fetchServiceDescription = async (endpointUrl, { headers, format }) => {
   const response = await rdf.fetch(endpointUrl, {
     headers: {
+      ...headers,
       Accept: format || '*/*',
-      authorization,
     },
   })
   return response.dataset()

--- a/packages/sparql-proxy/lib/serviceDescriptionWorker.js
+++ b/packages/sparql-proxy/lib/serviceDescriptionWorker.js
@@ -32,8 +32,8 @@ parentPort.once('message', async (message) => {
 
     try {
       const dataset = await fsd.fetchServiceDescription(endpointUrl, {
+        headers: rest.headers,
         format: rest.serviceDescriptionFormat,
-        authorization: rest.authorizationHeader,
       })
       clearTimeout(timeout)
 


### PR DESCRIPTION
This allows to send custom headers to the endpoint.
This is useful in case some users needs to use Bearer tokens (as mentioned in #673), … 