### PR TITLE
Fix(core): include `otel.js`

### DIFF
--- a/.changeset/thin-hotels-doubt.md
+++ b/.changeset/thin-hotels-doubt.md
@@ -1,0 +1,6 @@
+---
+"trifid-core": patch
+"trifid": patch
+---
+
+Include `otel.js` which was missing if using the npm module directly.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,7 @@
     "logo.svg",
     "index.js",
     "server.js",
+    "otel.js",
     "CHANGELOG.md"
   ],
   "main": "index.js",


### PR DESCRIPTION
The Docker container version was working as expected, but if a user was trying to import the `trifid-core` module using NPM he got the `otel.js` module is not found.

This should solve this issue.