### PR TITLE
Reduce OpenTelemetry cardinality

### DIFF
--- a/.changeset/quick-geckos-draw.md
+++ b/.changeset/quick-geckos-draw.md
@@ -1,6 +1,7 @@
 ---
 "trifid-handler-fetch": patch
 "@zazuko/trifid-plugin-sparql-proxy": patch
+"@zazuko/trifid-entity-renderer": patch
 "trifid": patch
 ---
 

--- a/.changeset/quick-geckos-draw.md
+++ b/.changeset/quick-geckos-draw.md
@@ -1,0 +1,7 @@
+---
+"trifid-handler-fetch": patch
+"@zazuko/trifid-plugin-sparql-proxy": patch
+"trifid": patch
+---
+
+Lower the OpenTelemetry cardinality

--- a/packages/entity-renderer/index.js
+++ b/packages/entity-renderer/index.js
@@ -192,7 +192,7 @@ const factory = async (trifid) => {
               const { responseCode, location } = entityRedirect
               if (responseCode && location && responseCode.value && location.value) {
                 logger.debug(`Redirecting <${iri}> to <${location.value}> (HTTP ${responseCode.value})`)
-                redirectedCounter.add(1, { iri, location: location.value, response_code: responseCode.value, endpoint_name: endpointName, kind: 'sparql' })
+                redirectedCounter.add(1, { response_code: responseCode.value, endpoint_name: endpointName, kind: 'sparql' })
                 reply.status(parseInt(responseCode.value, 10)).redirect(location.value)
                 return reply
               } else {
@@ -223,7 +223,7 @@ const factory = async (trifid) => {
           const quadStream = parsers.import(fixedContentType, entityStream)
 
           if (sparqlSupportedTypes.includes(acceptHeader)) {
-            dereferencedCounter.add(1, { iri, format: acceptHeader, endpoint_name: endpointName })
+            dereferencedCounter.add(1, { format: acceptHeader, endpoint_name: endpointName })
             const serialized = await sparqlSerializeQuadStream(quadStream, acceptHeader)
             reply.type(acceptHeader).send(serialized)
             return reply
@@ -243,7 +243,7 @@ const factory = async (trifid) => {
             if (!disabledSchemaUrlRedirect && urls.length > 0) {
               const redirectUrl = urls[0]
               logger.debug(`Redirecting to ${redirectUrl}`)
-              redirectedCounter.add(1, { iri, location: redirectUrl, response_code: 302, endpoint_name: endpointName, kind: 'schema_url' })
+              redirectedCounter.add(1, { response_code: 302, endpoint_name: endpointName, kind: 'schema_url' })
               reply.redirect(redirectUrl)
               return reply
             }
@@ -262,7 +262,7 @@ const factory = async (trifid) => {
           const metadata = await metadataProvider(request, { dataset })
           const jsonldSerialized = await sparqlSerializeQuadStream(dataset.toStream(), 'application/ld+json')
 
-          dereferencedCounter.add(1, { iri, format: 'text/html', endpoint_name: endpointName })
+          dereferencedCounter.add(1, { format: 'text/html', endpoint_name: endpointName })
           reply.type('text/html').send(await render(request, entityTemplatePath, {
             dataset: entityHtml,
             entityLabel,

--- a/packages/handler-fetch/index.js
+++ b/packages/handler-fetch/index.js
@@ -1,6 +1,5 @@
 // @ts-check
 
-import { createHash } from 'node:crypto'
 import { Worker } from 'node:worker_threads'
 import { performance } from 'node:perf_hooks'
 
@@ -184,7 +183,6 @@ export const factory = async (trifid) => {
         if (request.opentelemetry) {
           const { span } = request.opentelemetry()
           span.setAttribute('db.system', 'sparql')
-          span.setAttribute('sparql.query.hash', createHash('sha256').update(query).digest('hex'))
           span.addEvent('sparql.query', { statement: query })
 
           sparqlQueryCounter.add(1, { method })

--- a/packages/sparql-proxy/index.js
+++ b/packages/sparql-proxy/index.js
@@ -4,7 +4,6 @@ import { Readable } from 'node:stream'
 import { ReadableStream } from 'node:stream/web'
 import { performance } from 'node:perf_hooks'
 import { Worker } from 'node:worker_threads'
-import { createHash } from 'node:crypto'
 
 import { metrics } from '@opentelemetry/api'
 import rdf from '@zazuko/env-node'
@@ -325,7 +324,6 @@ const factory = async (trifid) => {
         if (request.opentelemetry) {
           const { span } = request.opentelemetry()
           span.setAttribute('db.system', 'sparql')
-          span.setAttribute('sparql.query.hash', createHash('sha256').update(query).digest('hex'))
           span.addEvent('sparql.query', { statement: query })
 
           sparqlQueryCounter.add(1, { endpoint_name: endpointName, method })


### PR DESCRIPTION
The current implementation could theoretically explode the number of generated metrics.
This PR tries to find the right balance.