### PR TITLE
[Docker] Upgrade base image to node 24

### DIFF
--- a/.changeset/real-cities-unite.md
+++ b/.changeset/real-cities-unite.md
@@ -1,0 +1,5 @@
+---
+"trifid": patch
+---
+
+Upgrade container base image to Node 24.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:22-alpine
+FROM docker.io/library/node:24-alpine
 
 EXPOSE 8080
 


### PR DESCRIPTION
This upgrades the Docker base image to Node.js 24, which is the current LTS now.