### PR TITLE
Remove DEP0155 warnings

### DIFF
--- a/.changeset/graph-explorer-dep0155.md
+++ b/.changeset/graph-explorer-dep0155.md
@@ -1,0 +1,10 @@
+---
+"trifid-plugin-graph-explorer": patch
+---
+
+Resolve the Graph Explorer assets without a trailing slash.
+
+`graph-explorer` ships no `exports` field, so this specifier did not trigger the
+`DEP0155` deprecation warning yet, but it would as soon as the package adds one.
+
+The resolved directory, and therefore the files being served, are unchanged.

--- a/.changeset/yasgui-dep0155.md
+++ b/.changeset/yasgui-dep0155.md
@@ -1,0 +1,18 @@
+---
+"trifid-plugin-yasgui": patch
+---
+
+Resolve the YASGUI assets without a trailing slash, to stop Node from printing a
+deprecation warning on every startup:
+
+```
+[DEP0155] DeprecationWarning: Use of deprecated trailing slash pattern mapping
+"./build/" in the "exports" field module resolution of the package at
+@zazuko/yasgui/package.json
+```
+
+The specifier ended with a slash, which Node resolves through the deprecated
+trailing slash pattern mapping of the `exports` field. `@zazuko/yasgui` itself
+uses the modern `"./*"` subpath pattern, so only the specifier had to change.
+
+The resolved directory, and therefore the files being served, are unchanged.

--- a/packages/graph-explorer/index.ts
+++ b/packages/graph-explorer/index.ts
@@ -40,7 +40,7 @@ const factory: TrifidPlugin = async (trifid) => {
     typeof template === 'string' && template ? template : `${currentDir}/views/graph-explorer.hbs`;
 
   // Serve static files for graph-explorer
-  const distPath = resolve('graph-explorer/dist/', import.meta.url);
+  const distPath = resolve('graph-explorer/dist', import.meta.url);
   server.register(fastifyStatic, {
     root: distPath.replace(/^file:\/\//, ''),
     prefix: joinSubpath(subpath, '/graph-explorer/assets/'),

--- a/packages/yasgui/index.ts
+++ b/packages/yasgui/index.ts
@@ -30,7 +30,7 @@ const trifidFactory: TrifidPlugin = async (trifid) => {
   }
 
   // Serve static files for YASGUI
-  const yasguiPath = resolve('@zazuko/yasgui/build/', import.meta.url);
+  const yasguiPath = resolve('@zazuko/yasgui/build', import.meta.url);
   server.register(fastifyStatic, {
     root: yasguiPath.replace(/^file:\/\//, ''),
     prefix: joinSubpath(subpath, '/yasgui-dist/'),


### PR DESCRIPTION
Using recent Node.js version, a `DEP0155` deprecation warning was shown.
This PR fixes this.